### PR TITLE
Hide action logger on homepage

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -6,7 +6,9 @@ import { requireContextPolyfill } from "./utils";
 import Welcome from "./Welcome";
 
 const stories = storiesOf("Introduzione", module);
-stories.add("Benvenuto", () => <Welcome />);
+stories
+  .addParameters({ options: { showAddonPanel: false } })
+  .add("Benvenuto", () => <Welcome />);
 
 // Used by Jest
 if (process.env.NODE_ENV === "test") {


### PR DESCRIPTION
Fixes #63 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This change will hide the addon panel. By default, it will remain hidden unless toggled.

#### Changes proposed in this pull request:

- By default, the addon panel will remain hidden.
- A better approach would be to show addon panel when the component story is clicked. I think this is open to discussion though.



