### PR TITLE
Fix yarn storybook:serve

### DIFF
--- a/README.EN.md
+++ b/README.EN.md
@@ -47,7 +47,7 @@ Public version of Storybook (built from `master` branch) is available [here](htt
 
 ## Getting started
 
-Clone the repo and run `yarn storybook` to start the development server.
+Clone the repo and run `yarn storybook:serve` to start the development server.
 A script takes care of running the `yarn install` command needed to install dependencies.
 
 Storybook will therefore be available at http://localhost:6006

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ La versione pubblica dello Storybook (relativa al branch `master`) è disponibil
 
 ## Come iniziare
 
-Clona il repository ed esegui `yarn storybook-serve` per avviare il server di sviluppo.
+Clona il repository ed esegui `yarn storybook:serve` per avviare il server di sviluppo.
 Uno script si occuperà di eseguire il comando `yarn install` necessario ad installare le dipendenze. 
 
 Storybook sarà quindi disponibile all'indirizzo http://localhost:6006


### PR DESCRIPTION

Fixes #99

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `next` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Starting script was breaking.

#### Changes proposed in this pull request:
- It should be `yarn storybook:serve` and not `yarn storybook-serve`.



