### PR TITLE
Fixes issue #94: Remove deprecated decorator checkA11y with withA11y

### DIFF
--- a/stories/Alert/Alert.stories.js
+++ b/stories/Alert/Alert.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 
 import { withKnobs, select, boolean } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -79,7 +79,7 @@ const EsempiInterattiviComponent = () => {
 };
 
 storiesOf("Componenti/Alert", module)
-    .addDecorator(checkA11y)
+    .addDecorator(withA11y)
     .add("Esempi", EsempiComponent, {info:{text: Esempi}})
     .add("Link evidenziato", LinkEvidenziatoComponent, {info:{text: LinkEvidenziato}})
     .add("Contenuto aggiuntivo", ContenutoAggiuntivoComponent, {info:{text: ContenutoAggiuntivo}})
@@ -87,7 +87,7 @@ storiesOf("Componenti/Alert", module)
     .add("Esempi Interattivi", EsempiInterattiviComponent, {info:{text: EsempiInterattivi}})
 
 storiesOf("Componenti/Alert/Chiusura", module)
-    .addDecorator(checkA11y)
+    .addDecorator(withA11y)
     .add("Non controllata", ChiusuraNonControllataComponent, {
         info:{
             text: Chiusura,

--- a/stories/Autocomplete/Autocomplete.stories.js
+++ b/stories/Autocomplete/Autocomplete.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -10,7 +10,7 @@ import AutocompleteExample from "./AutocompleteExample";
 import InputAutocomplete from "./InputAutocomplete.md";
 
 const stories = storiesOf("Componenti/Autocomplete", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Input autocomplete",

--- a/stories/Badge/Badge.stories.js
+++ b/stories/Badge/Badge.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -132,7 +132,7 @@ const EsempiInterattiviComponent = () => {
 };
 
 storiesOf("Componenti/Badge", module)
-    .addDecorator(checkA11y)
+    .addDecorator(withA11y)
     .addDecorator(withKnobs)
     .add("Esempi", withDocs(Esempi, withInfo()(EsempiComponent)))
     .add("Contatore", withDocs(Contatore, withInfo({propTablesExclude: [Button]})(ContatoreComponent)))

--- a/stories/Breadcrumb/Breadcrumb.stories.js
+++ b/stories/Breadcrumb/Breadcrumb.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -11,7 +11,7 @@ import Icone from "./Icone.md";
 import Background from "./Background.md";
 
 const stories = storiesOf("Componenti/Breadcrumb", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <section>

--- a/stories/Button/Button.stories.js
+++ b/stories/Button/Button.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -14,7 +14,7 @@ import StatoDisabilitato from "./StatoDisabilitato.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Button", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const colors = [
     "Primary",
@@ -121,7 +121,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/Button", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Card/Card.stories.js
+++ b/stories/Card/Card.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -36,7 +36,7 @@ import Deck from "./Deck.md";
 import Colonne from "./Colonne.md";
 
 const stories = storiesOf("Componenti/Card", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <Card className="w-50">

--- a/stories/Carousel/Carousel.stories.js
+++ b/stories/Carousel/Carousel.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -19,7 +19,7 @@ import ConIndicatori from "./ConIndicatori.md";
 import ConDidascalie from "./ConDidascalie.md";
 
 const stories = storiesOf("Componenti/Carousel", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Solo diapositive",

--- a/stories/Checkbox/Checkbox.stories.js
+++ b/stories/Checkbox/Checkbox.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -16,7 +16,7 @@ import Gruppi from "./Gruppi.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Checkbox", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <Form>
@@ -101,7 +101,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/Checkbox", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Collapse/Collapse.stories.js
+++ b/stories/Collapse/Collapse.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -17,7 +17,7 @@ import AccordionEsempio from "./AccordionEsempio.md";
 import Innestati from "./Innestati.md";
 
 const stories = storiesOf("Componenti/Collapse", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempi",

--- a/stories/Dropdown/Dropdown.stories.js
+++ b/stories/Dropdown/Dropdown.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -29,7 +29,7 @@ import MenuIconLeft from "./MenuIconLeft.md";
 import MenuDark from "./MenuDark.md";
 
 const stories = storiesOf("Componenti/Dropdown", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempi",
@@ -93,7 +93,7 @@ stories.add(
 );
 
 const menuStories = storiesOf("Componenti/Dropdown/Dropdown menu", module);
-menuStories.addDecorator(checkA11y);
+menuStories.addDecorator(withA11y);
 
 const MenuVociAttiveComponent = () => (
     <div className="clearfix">

--- a/stories/Form/Form.stories.js
+++ b/stories/Form/Form.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -61,7 +61,7 @@ import TestoAiuto from "./TestoAiuto.md";
 import FormDisabilitato from "./FormDisabilitato.md";
 
 const stories = storiesOf("Componenti/Form", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <Form>
@@ -464,7 +464,7 @@ stories.add(
 );
 
 const moreStories = storiesOf("Componenti/Form/Layout", module);
-moreStories.addDecorator(checkA11y);
+moreStories.addDecorator(withA11y);
 
 const FormGroupEsempioComponent = () => (
     <Form>

--- a/stories/Hero/Hero.stories.js
+++ b/stories/Hero/Hero.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -10,7 +10,7 @@ import Esempi from "./Esempi.md";
 import Fluid from "./Fluid.md";
 
 const stories = storiesOf("Componenti/Hero", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <Hero className="hero w-50">

--- a/stories/InputGroup/InputGroup.stories.js
+++ b/stories/InputGroup/InputGroup.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -29,7 +29,7 @@ import BottoniDropdown from "./BottoniDropdown.md";
 import PulsantiSegmentati from "./PulsantiSegmentati.md";
 
 const stories = storiesOf("Componenti/Input Group", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <div className="p-3">

--- a/stories/LinkList/LinkList.stories.js
+++ b/stories/LinkList/LinkList.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -33,7 +33,7 @@ import Navigation from "./Navigation.md";
 import Collapsible from "./Collapsible.md";
 
 const stories = storiesOf("Componenti/LinkList", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <LinkList>
@@ -153,7 +153,7 @@ const LargeComponent = () => (
 stories.add("Sizing", withDocs(Large, withInfo()(LargeComponent)));
 
 const multilineStories = storiesOf("Componenti/LinkList/Multiline", module);
-multilineStories.addDecorator(checkA11y);
+multilineStories.addDecorator(withA11y);
 
 const MultilineComponent = () => (
     <LinkList multiline>
@@ -182,7 +182,7 @@ multilineStories.add(
 );
 
 const controlStories = storiesOf("Componenti/LinkList/Con controlli", module);
-multilineStories.addDecorator(checkA11y);
+multilineStories.addDecorator(withA11y);
 
 const ControlliComponent = () => (
     <LinkList>
@@ -332,7 +332,7 @@ const navigationStories = storiesOf(
     "Componenti/LinkList/Nested navigation",
     module
 );
-navigationStories.addDecorator(checkA11y);
+navigationStories.addDecorator(withA11y);
 
 const NavigationComponent = () => (
     <LinkList>

--- a/stories/ListGroup/ListGroup.stories.js
+++ b/stories/ListGroup/ListGroup.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -18,7 +18,7 @@ import ContenutoPersonalizzato from "./ContenutoPersonalizzato.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/ListGroup", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <ListGroup className="w-50">
@@ -228,7 +228,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/ListGroup", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Modal/Modal.stories.js
+++ b/stories/Modal/Modal.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -23,7 +23,7 @@ import Dimensioni from "./Dimensioni.md";
 import ModalVariabile from "./ModalVariabile.md";
 
 const stories = storiesOf("Componenti/Modal", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <div style={{ padding: "0px 290px" }}>

--- a/stories/Nav/Nav.stories.js
+++ b/stories/Nav/Nav.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, boolean } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -15,7 +15,7 @@ import FillJustify from "./FillJustify.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Nav", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <div>
@@ -151,7 +151,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/Nav", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Navbar/Navbar.stories.js
+++ b/stories/Navbar/Navbar.stories.js
@@ -6,7 +6,7 @@ import {
     boolean,
     color
 } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -36,7 +36,7 @@ import Inline from "./Inline.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Navbar", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempi",
@@ -112,7 +112,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/Navbar", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Offcanvas/Offcanvas.stories.js
+++ b/stories/Offcanvas/Offcanvas.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { Viewport } from "@storybook/addon-viewport";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -12,7 +12,7 @@ import OffcanvasExample from "./OffcanvasExample";
 import Esempi from "./Esempi.md";
 
 const stories = storiesOf("Componenti/Offcanvas", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempio",

--- a/stories/Pager/Pager.stories.js
+++ b/stories/Pager/Pager.stories.js
@@ -2,7 +2,7 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, boolean } from "@storybook/addon-knobs/react";
 import { Viewport } from "@storybook/addon-viewport";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -31,7 +31,7 @@ import Total from "./Total.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Pager", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <Pager>
@@ -196,7 +196,7 @@ stories.add(
 );
 
 const moreStories = storiesOf("Componenti/Pager/Funzioni aggiuntive", module);
-moreStories.addDecorator(checkA11y);
+moreStories.addDecorator(withA11y);
 
 const MoreComponent = () => (
     <Pager className="mb-3">
@@ -496,7 +496,7 @@ const TotalComponent = () => (
 moreStories.add("Total number", withDocs(Total, withInfo()(TotalComponent)));
 
 const knobsStories = storiesOf("Componenti/Pager", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Popover/Popover.stories.js
+++ b/stories/Popover/Popover.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -18,7 +18,7 @@ import ElementiDisabilitati from "./ElementiDisabilitati.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Popover", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempi",
@@ -77,7 +77,7 @@ const store = new Store({
 });
 
 const knobsStories = storiesOf("Componenti/Popover", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Progress/Progress.stories.js
+++ b/stories/Progress/Progress.stories.js
@@ -7,7 +7,7 @@ import {
     select,
     boolean
 } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -20,7 +20,7 @@ import Background from "./Background.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Progress", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <div>
@@ -61,7 +61,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/Progress", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Radio/Radio.stories.js
+++ b/stories/Radio/Radio.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -16,7 +16,7 @@ import GruppiRadioButtons from "./GruppiRadioButtons.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Radio Button", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <fieldset>
@@ -126,7 +126,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/Radio Button", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Scrollspy/Scrollspy.stories.js
+++ b/stories/Scrollspy/Scrollspy.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -13,7 +13,7 @@ import BarraDiNavigazione from "./BarraDiNavigazione.md";
 import ListaElenco from "./ListaElenco.md";
 
 const stories = storiesOf("Componenti/Scrollspy", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempio in barra di navigazione",

--- a/stories/Select/Select.stories.js
+++ b/stories/Select/Select.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -13,7 +13,7 @@ import ConRicerca from "./ConRicerca.md";
 import ConGruppiOpzioni from "./ConGruppiOpzioni.md";
 
 const stories = storiesOf("Componenti/Select", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempi",

--- a/stories/Skiplink/Skiplink.stories.js
+++ b/stories/Skiplink/Skiplink.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -11,7 +11,7 @@ import SkipLinkExample from "./SkipLinkExample";
 import Esempi from "./Esempi.md";
 
 const stories = storiesOf("Componenti/Skiplink", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempi",

--- a/stories/Tab/Tab.stories.js
+++ b/stories/Tab/Tab.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -17,7 +17,7 @@ import TabBottoni from "./TabBottoni.md";
 import AllineamentoVerticale from "./AllineamentoVerticale.md";
 
 const stories = storiesOf("Componenti/Tab", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => (
     <div>

--- a/stories/Toggle/Toggles.stories.js
+++ b/stories/Toggle/Toggles.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, boolean, text } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs } from "../utils";
 
@@ -26,7 +26,7 @@ import EsempiMarkup from "./EsempiMarkup.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Toggles", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 stories.add(
     "Esempi",
@@ -62,7 +62,7 @@ stories.add(
 );
 
 const knobsStories = storiesOf("Componenti/Toggles", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {

--- a/stories/Tooltip/Tooltip.stories.js
+++ b/stories/Tooltip/Tooltip.stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, text, select } from "@storybook/addon-knobs/react";
-import { checkA11y } from "@storybook/addon-a11y";
+import { withA11y } from "@storybook/addon-a11y";
 import { withInfo } from "@storybook/addon-info";
 import { withDocs, envIs } from "../utils";
 
@@ -12,7 +12,7 @@ import Posizioni from "./Posizioni.md";
 import EsempiInterattivi from "./EsempiInterattivi.md";
 
 const stories = storiesOf("Componenti/Tooltip", module);
-stories.addDecorator(checkA11y);
+stories.addDecorator(withA11y);
 
 const EsempiComponent = () => {
     if (envIs("test")) {
@@ -125,7 +125,7 @@ const PosizioniComponent = () => {
 stories.add("Posizioni", withDocs(Posizioni, withInfo()(PosizioniComponent)));
 
 const knobsStories = storiesOf("Componenti/Tooltip", module);
-knobsStories.addDecorator(checkA11y);
+knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
 const EsempiInterattiviComponent = () => {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #94 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `next` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
decorator `checkA11y` is deprecated in storybook v5.0.0^  so it has been replaced with `withA11y`. 

#### Changes proposed in this pull request:

`checkA11y` has been replaced with `withA11y`

