### PR TITLE
Remove Autocomplete cross button

### DIFF
--- a/src/components/Autocomplete/Autocomplete.js
+++ b/src/components/Autocomplete/Autocomplete.js
@@ -217,10 +217,11 @@ class Autocomplete extends Component {
     const {
       options,
       placeholder,
-      isLabelActive,
       menuIsOpen,
       ...rest
     } = this.props;
+
+    const isLabelActive = !!inputText;
 
     const classNames = isLabelActive ? 'active' : '';
 

--- a/src/components/Autocomplete/Autocomplete.js
+++ b/src/components/Autocomplete/Autocomplete.js
@@ -30,30 +30,12 @@ SelectContainer.propTypes = {
 };
 
 const Control = (props) => {
-  const { children, innerProps, selectProps } = props;
+  const { children, innerProps } = props;
   const { innerRef, ...rest } = innerProps;
-  const { inputValue, onInputClear } = selectProps;
 
-  const hasValue = !!inputValue;
 
   return (
     <div className="autocomplete-control" {...rest}>
-      <button
-        className="autocomplete-clear"
-        style={{ visibility: hasValue ? 'visible' : 'hidden' }}
-        onClick={onInputClear}
-      >
-        <svg
-          fill="#000000"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="https://www.w3.org/2000/svg"
-        >
-          <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
-          <path d="M0 0h24v24H0z" fill="none" />
-        </svg>
-      </button>
       {children}
     </div>
   );


### PR DESCRIPTION

Fixes #115 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `next` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR removes the explicit cross button being used and switch to `react-select` cross button inside the Input Field.
It also fixes the Overlapping of typed text with `Label` while typing as the `active` class has been the issue all across as mentioned in issue #114 

Current State:
![Screenshot from 2019-03-17 12-50-32](https://user-images.githubusercontent.com/12708871/54487036-8ab6e300-48b6-11e9-9cd6-3b2410b04535.png)

Expected State:
![Screenshot from 2019-03-17 13-14-31](https://user-images.githubusercontent.com/12708871/54487047-b8039100-48b6-11e9-960d-5d0db7dcb159.png)




