### PR TITLE
Toggle of nested headers fixed

### DIFF
--- a/stories/Collapse/CollapseNestedExample.js
+++ b/stories/Collapse/CollapseNestedExample.js
@@ -75,7 +75,6 @@ class CollapseNestedPanel extends React.Component {
 
     toggle = id => {
         this.setState({
-            ...this.defaultState,
             [`collapseOpen${id}`]: !this.state[`collapseOpen${id}`]
         });
     };


### PR DESCRIPTION

Fixes #126 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `next` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

This resolves the issue which existed in the nested headers of `Collapse e Accordion innestati` tab of `Collapse` Component where the nested header remained in the default state when another nested header was being clicked. 
Due to this all other headers where forced to be closed even on initial as well as in normal state.




