### PR TITLE
Fixed the label position in Select Component

### DIFF
--- a/stories/Select/SelectExample.js
+++ b/stories/Select/SelectExample.js
@@ -86,6 +86,7 @@ class SelectExample extends React.Component {
         return (
             <FormGroup className="m-3">
                 {icon ? <i className="ico-prefix it-youtube" /> : null}
+                <Label style={{position: 'static'}}>Label di esempio</Label>
                 <Select
                     classic={classic}
                     options={options}
@@ -99,8 +100,7 @@ class SelectExample extends React.Component {
                     isMulti={multi}
                     searchPlaceholder="Cerca una regione"
                 />
-                <br/>
-                <Label style={{top: 'unset'}}>Label di esempio</Label>
+                <br/> 
             </FormGroup>
         );
     }


### PR DESCRIPTION
Fixed the label position in the Select Component

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `next` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
The Labels should be placed on the Top of the fields.
#### Initial condition
![image](https://user-images.githubusercontent.com/33497630/54688486-b0a4e780-4b43-11e9-93f3-33ba54ee5228.png)


#### After the Fix
![image](https://user-images.githubusercontent.com/33497630/54688303-66236b00-4b43-11e9-952f-6e745d4302c0.png)


#### Changes proposed in this pull request:
- Fixed the position.

