### PR TITLE
Stories => Broken Popover Issue solved

### DIFF
--- a/stories/Popover/Popover.stories.js
+++ b/stories/Popover/Popover.stories.js
@@ -72,10 +72,6 @@ stories.add(
     )
 );
 
-const store = new Store({
-    isOpen: false
-});
-
 const knobsStories = storiesOf("Componenti/Popover", module);
 knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
@@ -89,7 +85,9 @@ const EsempiInterattiviComponent = () => {
         "Body",
         "Ed ecco alcuni contenuti sorprendenti. È molto coinvolgente. Non trovi?"
     );
-
+    const store = new Store({
+        isOpen: false
+    });
     const id = "example";
     // Avoid Jest complaints
     const target = () => document.getElementById(id);


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #142 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `next` branch.
- [x] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR is aimed to solve the problem mentioned in Issue #142.
According to the current implementation of Popover, it is necessary to pass a target in the Popover. The target for Popover gets lost whenever a user switches to some other component screen. Maintaining the state of Popover according to User Screen solves the Issue. 

#### Changes proposed in this pull request:
- The Store of Component  Esempi Interattivi was shifted from outside to the inside of the Component so that it provides control State according to component rendering. 
 