### PR TITLE
Stories => Broken Popover Issue solved

### DIFF
--- a/stories/Popover/Popover.stories.js
+++ b/stories/Popover/Popover.stories.js
@@ -84,15 +84,6 @@ knobsStories.addDecorator(withKnobs);
 class EsempiInterattiviComponent extends React.Component {
     constructor(props) {
         super(props);
-        //All the constants required by Component are changed to Class Members
-        this.disabled = boolean("Disabilitato", false);
-        this.placements = ["top", "bottom", "left", "right"];
-        this.placement = select("Posizione", this.placements, this.placements[0]);
-        this.title = text("Titolo", "Titolo del popover");
-        this.body = text(
-            "Body",
-            "Ed ecco alcuni contenuti sorprendenti. È molto coinvolgente. Non trovi?"
-        );
         this.id = "example";
         // Avoid Jest complaints
         this.target = () => document.getElementById(this.id);
@@ -107,21 +98,21 @@ class EsempiInterattiviComponent extends React.Component {
                 <Button
                     id={this.id}
                     color="primary"
-                    disabled={this.disabled}
+                    disabled={this.props.disabled}
                     onClick={() => store.set({ isOpen: !store.get("isOpen") })}
                 >
-                    Popover {this.disabled ? "Disabilitato" : ""}
+                    Popover {this.props.disabled ? "Disabilitato" : ""}
                 </Button>
 
                 <State store={store}>
                     <Popover
-                        placement={this.placement}
+                        placement={this.props.placement}
                         target={this.target}
                         toggle={() => store.set({ isOpen: !store.get("isOpen") })}
                         isOpen={store.get("isOpen")}
                     >
-                        <PopoverHeader>{this.title}</PopoverHeader>
-                        <PopoverBody>{this.body}</PopoverBody>
+                        <PopoverHeader>{this.props.title}</PopoverHeader>
+                        <PopoverBody>{this.props.body}</PopoverBody>
                     </Popover>
                 </State>
             </div>
@@ -134,6 +125,23 @@ knobsStories.add(
         EsempiInterattivi,
         withInfo({
             propTablesExclude: [Button, State]
-        })(props => <EsempiInterattiviComponent {...props} />)
+        })(props => {
+            //All the proerties for Addon Knobs are placed back in the function
+            const disabled = boolean("Disabilitato", false);
+            const placements = ["top", "bottom", "left", "right"];
+            const placement = select("Posizione", placements, placements[0]);
+            const title = text("Titolo", "Titolo del popover");
+            const body = text(
+                "Body",
+                "Ed ecco alcuni contenuti sorprendenti. È molto coinvolgente. Non trovi?"
+            );
+            //All the knob properties are passed as props
+            return <EsempiInterattiviComponent
+                disabled={disabled}
+                placement={placement}
+                title={title}
+                body={body}
+                {...props} />
+        })
     )
 );

--- a/stories/Popover/Popover.stories.js
+++ b/stories/Popover/Popover.stories.js
@@ -80,44 +80,53 @@ const knobsStories = storiesOf("Componenti/Popover", module);
 knobsStories.addDecorator(withA11y);
 knobsStories.addDecorator(withKnobs);
 
-const EsempiInterattiviComponent = () => {
-    const disabled = boolean("Disabilitato", false);
-    const placements = ["top", "bottom", "left", "right"];
-    const placement = select("Posizione", placements, placements[0]);
-    const title = text("Titolo", "Titolo del popover");
-    const body = text(
-        "Body",
-        "Ed ecco alcuni contenuti sorprendenti. È molto coinvolgente. Non trovi?"
-    );
-
-    const id = "example";
-    // Avoid Jest complaints
-    const target = () => document.getElementById(id);
-
-    return (
-        <div style={{ padding: 250, textAlign: "center"}}>
-            <Button
-                id={id}
-                color="primary"
-                disabled={disabled}
-                onClick={() => store.set({ isOpen: !store.get("isOpen") })}
-            >
-                Popover {disabled ? "Disabilitato" : ""}
-            </Button>
-
-            <State store={store}>
-                <Popover
-                    placement={placement}
-                    target={target}
-                    toggle={() => store.set({ isOpen: !store.get("isOpen") })}
-                    isOpen={store.get("isOpen")}
+//Changed The Functional Component to a Class
+class EsempiInterattiviComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        //All the constants required by Component are changed to Class Members
+        this.disabled = boolean("Disabilitato", false);
+        this.placements = ["top", "bottom", "left", "right"];
+        this.placement = select("Posizione", this.placements, this.placements[0]);
+        this.title = text("Titolo", "Titolo del popover");
+        this.body = text(
+            "Body",
+            "Ed ecco alcuni contenuti sorprendenti. È molto coinvolgente. Non trovi?"
+        );
+        this.id = "example";
+        // Avoid Jest complaints
+        this.target = () => document.getElementById(this.id);
+    }
+    //All a LifeCycle Method to manage the store State when components unrender.
+    componentWillUnmount() {
+        store.set({ isOpen: false });
+    }
+    render() {
+        return (
+            <div style={{ padding: 250, textAlign: "center" }}>
+                <Button
+                    id={this.id}
+                    color="primary"
+                    disabled={this.disabled}
+                    onClick={() => store.set({ isOpen: !store.get("isOpen") })}
                 >
-                    <PopoverHeader>{title}</PopoverHeader>
-                    <PopoverBody>{body}</PopoverBody>
-                </Popover>
-            </State>
-        </div>
-    );
+                    Popover {this.disabled ? "Disabilitato" : ""}
+                </Button>
+
+                <State store={store}>
+                    <Popover
+                        placement={this.placement}
+                        target={this.target}
+                        toggle={() => store.set({ isOpen: !store.get("isOpen") })}
+                        isOpen={store.get("isOpen")}
+                    >
+                        <PopoverHeader>{this.title}</PopoverHeader>
+                        <PopoverBody>{this.body}</PopoverBody>
+                    </Popover>
+                </State>
+            </div>
+        );
+    }
 };
 knobsStories.add(
     "Esempi interattivi",
@@ -125,6 +134,6 @@ knobsStories.add(
         EsempiInterattivi,
         withInfo({
             propTablesExclude: [Button, State]
-        })(EsempiInterattiviComponent)
+        })(props => <EsempiInterattiviComponent {...props} />)
     )
 );


### PR DESCRIPTION

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #142 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `next` branch.
- [x] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
This PR is aimed to solve the problem mentioned in Issue #142.
According to the current implementation of Popover, it is necessary to pass a target in the Popover. The target for Popover gets lost whenever a user switches to some other component screen. Maintaining the state of Popover according to User Screen solves the Issue. 

#### Changes proposed in this pull request:
- Funtioncal Component Esempi Interattivi is changed to a Class Component
- ComponentWillUnmount lifecycle method is implemented to handle the store state on component unmounting.
