### PR TITLE
Made bootstrap and fonts installed separately

### DIFF
--- a/README.EN.md
+++ b/README.EN.md
@@ -46,7 +46,17 @@ $ cd nome-app
 $ yarn add design-react-kit --save
 ```
 
-Then, you just need to import CSS e font that are already included in the `design-react-kit` npm package, editing `./src/App.js` as shown:
+## Add bootstrap-italia and fonts
+
+The `design-react-kit` module does not include the CSS and font files in the bundle, so this needs to be installed as well:
+
+```sh
+$ yarn add bootstrap-italia typeface-lora typeface-roboto-mono typeface-titillium-web --save
+```
+
+## App.js
+
+Then, you just need to import CSS e font editing `./src/App.js` as shown:
 
 ```jsx
 import React from 'react';

--- a/README.md
+++ b/README.md
@@ -45,7 +45,17 @@ $ cd nome-app
 $ yarn add design-react-kit --save
 ```
 
-A questo punto, è sufficiente importare esplicitamente nella app CSS e font già inclusi nel pacchetto npm `design-react-kit`, se si è usato `create-react-app` all'interno del file `./src/App.js`:
+## Aggiungere bootstrap-italia ed i font
+
+Il `design-react-kit` non include il CSS ed i file font, ed è quindi necessario installarli a parte:
+
+```sh
+$ yarn add bootstrap-italia typeface-lora typeface-roboto-mono typeface-titillium-web --save
+```
+
+## App.js
+
+A questo punto, è sufficiente importare esplicitamente nella app CSS e font se si è usato `create-react-app` all'interno del file `./src/App.js`:
 
 ```jsx
 import React from 'react';

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@storybook/react": "^5.1.11",
         "babel-eslint": "^10.0.2",
         "babel-loader": "^8.0.6",
+        "bootstrap-italia": "1.3.4",
         "classnames": "^2.2.6",
         "eslint": "^6.2.0",
         "eslint-config-airbnb": "^17.1.1",
@@ -63,7 +64,10 @@
         "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-replace": "^2.2.0",
         "rollup-plugin-svg": "^2.0.0",
-        "run-script-os": "^1.0.7"
+        "run-script-os": "^1.0.7",
+        "typeface-lora": "^0.0.72",
+        "typeface-roboto-mono": "^0.0.75",
+        "typeface-titillium-web": "^0.0.72"
     },
     "peerDependencies": {
         "react": "^16.8.3",
@@ -89,14 +93,10 @@
         }
     },
     "dependencies": {
-        "bootstrap-italia": "1.3.4",
         "prop-types": "^15.7.2",
         "react-select": "^3.0.4",
         "react-transition-group": "^2.3.1",
         "reactstrap": "^8.0.0",
-        "typeface-lora": "^0.0.72",
-        "typeface-roboto-mono": "^0.0.75",
-        "typeface-titillium-web": "^0.0.72",
         "webfontloader": "^1.6.28"
     }
 }


### PR DESCRIPTION
Fixes #330

#### PR Checklist

- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

This PR makes explicit the `bootstrap-italia` and fonts dependency of this package to external applications. The readme has been updated accordingly to explain how to add these dependencies when creating a new app.

#### Changes proposed in this pull request:

- Moved deps to `dev-dependencies` group in `package.json`
- Updated both readmes


