### PR TITLE
Icon prop in Button component

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+
+import { Button as ButtonBase } from 'reactstrap'
+
+const propTypes = {
+  ...ButtonBase.propTypes,
+  icon: PropTypes.bool
+}
+
+const defaultProps = {
+  ...ButtonBase.defaultProps,
+  icon: false
+}
+
+const Button = ({ icon, className, ...attributes }) => {
+  const classes = classNames(className, {
+    'btn-icon': icon
+  })
+  return <ButtonBase className={classes} {...attributes} />
+}
+
+Button.propTypes = propTypes
+Button.defaultProps = defaultProps
+export default Button

--- a/src/components/Chips/Chip.js
+++ b/src/components/Chips/Chip.js
@@ -25,15 +25,21 @@ const defaultProps = {
 }
 
 const Chip = props => {
-  const { className, color, tag: Tag, simple, large, disabled, ...attributes } = props
+  const {
+    className,
+    color,
+    tag: Tag,
+    simple,
+    large,
+    disabled,
+    ...attributes
+  } = props
   const classes = classNames('chip', className, {
     'chip-simple': simple,
     'chip-lg': large,
     'chip-disabled': disabled,
     [`chip-${color}`]: color
-  
-  }
-);
+  })
 
   return <Tag className={classes} {...attributes} />
 }

--- a/src/components/CookieBar/CookieBarButton.js
+++ b/src/components/CookieBar/CookieBarButton.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 const propTypes = {
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  className: PropTypes.string
 }
 
 const defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ export {
   NavLink,
   Breadcrumb,
   BreadcrumbItem,
-  Button,
   ButtonDropdown,
   ButtonGroup,
   ButtonToolbar,
@@ -94,6 +93,7 @@ export {
 } from './components/Accordion/AccordionHeader'
 export { default as AccordionBody } from './components/Accordion/AccordionBody'
 export { default as Badge } from './components/Badge/Badge'
+export { default as Button } from './components/Button/Button'
 export { default as Collapse } from './components/Collapse/Collapse'
 export { default as FormGroup } from './components/FormGroup/FormGroup'
 export { default as Header } from './components/Header/Header'

--- a/stories/Button/Button.stories.js
+++ b/stories/Button/Button.stories.js
@@ -86,17 +86,17 @@ const DimensioniComponent = () => (
 
 const ButtonIconComponent = () => (
   <div>
-    <Button color="primary" size="lg" className="btn-icon">
-      <Icon color={'icon-white'} /> Icon Button Large
+    <Button color="primary" size="lg" icon>
+      <Icon color="white" icon="it-star-full" /> Icon Button Large
     </Button>{' '}
-    <Button color="success" className="btn-icon">
-      <Icon color={'icon-white'} /> Icon Button
+    <Button color="success" icon>
+      <Icon color="white" icon="it-star-full" /> Icon Button
     </Button>{' '}
-    <Button color="danger" size="sm" className="btn-icon">
-      <Icon color={'icon-primary'} /> Icon Button Small
+    <Button color="danger" size="sm" icon>
+      <Icon color="secondary" icon="it-star-full" /> Icon Button Small
     </Button>{' '}
-    <Button color="info" size="xs" className="btn-icon">
-      <Icon color={'icon-black'} icon={'it-help'} /> Icon Button Extra Small
+    <Button color="info" size="xs" icon>
+      <Icon color="danger" icon="it-star-full" /> Icon Button Extra Small
     </Button>
   </div>
 )

--- a/stories/Chips/Chips.stories.js
+++ b/stories/Chips/Chips.stories.js
@@ -187,30 +187,30 @@ const ChipGroupsComponent = () => (
 )
 
 const ColorChangeChipComponent = () => (
-    <Row>
+  <Row>
     <Col xs="12" md={{ size: 6 }}>
       <h4>Change Color of Chips</h4>
       <p className="mt-4 mb-2">Primary color</p>
-    <Chip simple color = "primary">
-      <ChipLabel>Primary</ChipLabel>
-    </Chip>
-    <p className="mt-4 mb-2">Warning Color</p>
-    <Chip simple color = "warning">
-      <ChipLabel>Warning</ChipLabel>
-    </Chip>
-    <p className="mt-4 mb-2">Success Color</p>
-    <Chip simple color = "success">
-      <ChipLabel>Success</ChipLabel>
-    </Chip>
-    <p className="mt-4 mb-2">Danger Color</p>
-    <Chip simple color = "danger">
-      <ChipLabel>Danger</ChipLabel>
-    </Chip>
-    <p className="mt-4 mb-2">Info Color</p>
-    <Chip simple color = "info">
-      <ChipLabel>Information</ChipLabel>
-    </Chip>
-  </Col>
+      <Chip simple color="primary">
+        <ChipLabel>Primary</ChipLabel>
+      </Chip>
+      <p className="mt-4 mb-2">Warning Color</p>
+      <Chip simple color="warning">
+        <ChipLabel>Warning</ChipLabel>
+      </Chip>
+      <p className="mt-4 mb-2">Success Color</p>
+      <Chip simple color="success">
+        <ChipLabel>Success</ChipLabel>
+      </Chip>
+      <p className="mt-4 mb-2">Danger Color</p>
+      <Chip simple color="danger">
+        <ChipLabel>Danger</ChipLabel>
+      </Chip>
+      <p className="mt-4 mb-2">Info Color</p>
+      <Chip simple color="info">
+        <ChipLabel>Information</ChipLabel>
+      </Chip>
+    </Col>
   </Row>
 )
 

--- a/stories/Cookiebar/Cookiebar.stories.js
+++ b/stories/Cookiebar/Cookiebar.stories.js
@@ -10,7 +10,7 @@ import { CookieBar, CookieBarButtons, CookieBarButton } from '../../src'
 
 const CookieBarComponent = () => {
   const open = boolean('show', true)
-  if (!open) return (null)
+  if (!open) return null
   else {
     return (
       <CookieBar>


### PR DESCRIPTION
Fixes #387 and partial #388 

#### PR Checklist

- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Add a convenient `icon` prop to the `Button` component extending the `reactstrap` one.

Also fixed the Button icon story:
<img width="835" alt="Screen Shot 2019-10-11 at 20 34 18" src="https://user-images.githubusercontent.com/924948/66675958-ca845400-ec66-11e9-8bfb-5bb11430d4ac.png">


#### Changes proposed in this pull request:

- :sparkles: Add a new prop to conveniently handle the `icon` scenario
- :bug: fix the button icon story
- 🚨 One more pass of linting fixes

