### PR TITLE
Refactor stories to correctly use the Icon component

### DIFF
--- a/stories/Breadcrumb/Breadcrumb.stories.js
+++ b/stories/Breadcrumb/Breadcrumb.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { withA11y } from '@storybook/addon-a11y'
 import { withInfo } from '@storybook/addon-info'
 
-import { Breadcrumb, BreadcrumbItem } from '../../src'
+import { Breadcrumb, BreadcrumbItem, Icon } from '../../src'
 
 import Esempi from './docs/Esempi.md'
 import Icone from './docs/Icone.md'
@@ -54,34 +54,37 @@ const IconeComponent = () => (
     <nav className="breadcrumb-container">
       <Breadcrumb>
         <BreadcrumbItem>
-          <i className="it-favorite" />
-          <svg
-            className="icon icon-sm icon-secondary align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="secondary"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">
             Home<span className="separator">/</span>
           </a>
         </BreadcrumbItem>
         <BreadcrumbItem>
-          <i className="it-favorite" />
-          <svg
-            className="icon icon-sm icon-secondary align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="secondary"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">
             Subsection<span className="separator">/</span>
           </a>
         </BreadcrumbItem>
         <BreadcrumbItem active>
-          <i className="it-favorite" />
-          <svg
-            className="icon icon-sm icon-secondary align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="secondary"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">Current section</a>
         </BreadcrumbItem>
       </Breadcrumb>
@@ -110,29 +113,35 @@ const BackgroundComponent = () => (
     <nav className="breadcrumb-container" aria-label="breadcrumb">
       <ol className="breadcrumb dark">
         <li className="breadcrumb-item">
-          <svg
-            className="icon icon-sm icon-white align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="white"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">Home</a>
           <span className="separator">/</span>
         </li>
         <li className="breadcrumb-item">
-          <svg
-            className="icon icon-sm icon-white align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="white"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">Subsection</a>
           <span className="separator">/</span>
         </li>
         <li className="breadcrumb-item active" aria-current="page">
-          <svg
-            className="icon icon-sm icon-white align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="white"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">Current section</a>
         </li>
       </ol>
@@ -141,29 +150,35 @@ const BackgroundComponent = () => (
     <nav className="breadcrumb-container" aria-label="breadcrumb">
       <ol className="breadcrumb dark">
         <li className="breadcrumb-item">
-          <svg
-            className="icon icon-sm icon-white align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="white"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">Home</a>
           <span className="separator">&gt;</span>
         </li>
         <li className="breadcrumb-item">
-          <svg
-            className="icon icon-sm icon-white align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="white"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">Subsection</a>
           <span className="separator">&gt;</span>
         </li>
         <li className="breadcrumb-item active" aria-current="page">
-          <svg
-            className="icon icon-sm icon-white align-top mr-1"
-            aria-hidden="true">
-            <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-          </svg>
+          <Icon
+            className="align-top mr-1"
+            icon="it-star-outline"
+            color="white"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <a href="#">Current section</a>
         </li>
       </ol>

--- a/stories/Dropdown/Dropdown.stories.js
+++ b/stories/Dropdown/Dropdown.stories.js
@@ -8,6 +8,7 @@ import {
   DropdownMenu,
   DropdownItem,
   DropdownToggle,
+  Icon,
   LinkList,
   LinkListItem
 } from '../../src'
@@ -142,15 +143,33 @@ const MenuIconRightComponent = () => (
       <LinkList>
         <LinkListItem className="right-icon">
           <span>Azione 1</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="primary"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
         <LinkListItem className="right-icon">
           <span>Azione 2</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="primary"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
         <LinkListItem className="right-icon">
           <span>Azione 3</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="primary"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
       </LinkList>
     </DropdownMenu>
@@ -162,15 +181,33 @@ const MenuIconLeftComponent = () => (
     <DropdownMenu isOpen className="d-block position-relative">
       <LinkList>
         <LinkListItem className="left-icon">
-          <i className="it-info left" />
+          <Icon
+            className="left"
+            color="primary"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <span>Azione 1</span>
         </LinkListItem>
         <LinkListItem className="left-icon">
-          <i className="it-info left" />
+          <Icon
+            className="left"
+            color="primary"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <span>Azione 2</span>
         </LinkListItem>
         <LinkListItem className="left-icon">
-          <i className="it-info left" />
+          <Icon
+            className="left"
+            color="primary"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
           <span>Azione 3</span>
         </LinkListItem>
       </LinkList>
@@ -185,24 +222,54 @@ const MenuDarkComponent = () => (
         <LinkListItem header>Header</LinkListItem>
         <LinkListItem active className="right-icon">
           <span>Azione 1 (attivo)</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="light"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
         <LinkListItem className="right-icon">
           <span>Azione 2</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="light"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
         <LinkListItem className="right-icon">
           <span>Azione 3</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="light"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
         <LinkListItem divider />
         <LinkListItem className="right-icon">
           <span>Azione 4</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="light"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
         <LinkListItem disabled className="right-icon">
           <span>Azione 5 (disabilitato)</span>
-          <i className="it-info right" />
+          <Icon
+            className="right"
+            color="light"
+            icon="it-info-circle"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </LinkListItem>
       </LinkList>
     </DropdownMenu>

--- a/stories/Form/Autocomplete/AutocompleteExample.js
+++ b/stories/Form/Autocomplete/AutocompleteExample.js
@@ -3,6 +3,7 @@ import { components } from 'react-select'
 import AsyncSelect from 'react-select/async'
 import './assets/css/autocomplete-styles.css'
 import PropTypes from 'prop-types'
+import { Icon } from '../../../src'
 
 const propTypes = {
   isHidden: PropTypes.bool
@@ -12,9 +13,7 @@ const DropdownIndicator = props => {
   return (
     <components.DropdownIndicator {...props}>
       <span style={{ padding: '0px 5px' }} aria-hidden="true">
-        <svg className="icon icon-sm">
-          <use xlinkHref="/svg/sprite.svg#it-search" />
-        </svg>
+        <Icon icon="it-search" style={{ ariaHidden: true }} size="sm" />
       </span>
     </components.DropdownIndicator>
   )

--- a/stories/Form/Input/InputIcon/InputIconButtonExample.js
+++ b/stories/Form/Input/InputIcon/InputIconButtonExample.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Icon } from '../../../../src'
 
 class InputIconButtonExample extends React.Component {
   constructor() {
@@ -29,9 +30,7 @@ class InputIconButtonExample extends React.Component {
           <div className="input-group">
             <div className="input-group-prepend">
               <div className="input-group-text">
-                <svg className="icon icon-sm">
-                  <use xlinkHref="/svg/sprite.svg#it-pencil" />
-                </svg>
+                <Icon icon="it-pencil" style={{ ariaHidden: true }} size="sm" />
               </div>
             </div>
             <label
@@ -62,9 +61,12 @@ class InputIconButtonExample extends React.Component {
           <div className="input-group">
             <div className="input-group-prepend">
               <div className="input-group-text">
-                <svg className="icon icon-sm icon-danger">
-                  <use xlinkHref="/svg/sprite.svg#it-pencil" />
-                </svg>
+                <Icon
+                  icon="it-pencil"
+                  color="danger"
+                  style={{ ariaHidden: true }}
+                  size="sm"
+                />
               </div>
             </div>
             <label htmlFor="input-group-2" className="active">
@@ -94,9 +96,12 @@ class InputIconButtonExample extends React.Component {
           <div className="input-group">
             <div className="input-group-prepend">
               <div className="input-group-text">
-                <svg className="icon icon-sm icon-primary">
-                  <use xlinkHref="/svg/sprite.svg#it-pencil" />
-                </svg>
+                <Icon
+                  icon="it-pencil"
+                  color="primary"
+                  style={{ ariaHidden: true }}
+                  size="sm"
+                />
               </div>
             </div>
             <label

--- a/stories/Form/Select/SelectExample.js
+++ b/stories/Form/Select/SelectExample.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Select, { components } from 'react-select'
+import { Icon } from '../../../src'
 import PropTypes from 'prop-types'
 import './assets/css/select-styles.css'
 
@@ -39,9 +40,7 @@ MenuList.propTypes = {
 const DropdownIndicator = props => {
   return (
     <components.DropdownIndicator {...props}>
-      <svg className="icon">
-        <use xlinkHref="/svg/sprite.svg#it-arrow-down-triangle" />
-      </svg>
+      <Icon icon="it-arrow-down-triangle" style={{ ariaHidden: true }} />
     </components.DropdownIndicator>
   )
 }

--- a/stories/Icon/Icon.stories.js
+++ b/stories/Icon/Icon.stories.js
@@ -21,7 +21,7 @@ storiesOf('Componenti/Icon', module)
         'Dimensioni',
         {
           'Extra small': 'xs',
-          Small: 'xs',
+          Small: 'sm',
           default: '',
           Large: 'lg',
           'Extra Large': 'xl'

--- a/stories/LinkList/LinkList.stories.js
+++ b/stories/LinkList/LinkList.stories.js
@@ -139,20 +139,36 @@ const MultilineComponent = () => (
     <LinkListItem active className="right-icon">
       <span>Link list 1 active</span>
       <i className="it-chevron-right right" />
-      <Icon icon="it-chevron-right" color="primary" className="icon-right" />
+      <Icon
+        className="icon-right"
+        color="primary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit…</p>
     </LinkListItem>
     <LinkListItem divider />
     <LinkListItem className="right-icon">
       <span>Link list 2</span>
       <i className="it-chevron-right right" />
+      <Icon
+        className="icon-right"
+        color="primary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit…</p>
     </LinkListItem>
     <LinkListItem divider />
     <LinkListItem disabled className="right-icon">
       <span>Link list 3 disabled</span>
       <i className="it-chevron-right right" />{' '}
-      <Icon icon="it-chevron-right" color="primary" className="icon-right" />
+      <Icon
+        className="icon-right"
+        color="primary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit…</p>
     </LinkListItem>
   </LinkList>
@@ -162,17 +178,32 @@ const ControlliComponent = () => (
   <LinkList>
     <LinkListItem active className="left-icon">
       <i className="it-chevron-right left" aria-hidden="true" />
-      <Icon icon="it-chevron-right" color="primary" />
+      <Icon
+        className="left"
+        color="primary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
       <span>Link list 1 active</span>
     </LinkListItem>
     <LinkListItem className="left-icon">
       <i className="it-chevron-right left" aria-hidden="true" />
-      <Icon icon="it-chevron-right" color="primary" />
+      <Icon
+        className="left"
+        color="primary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
       <span>Link list 2</span>
     </LinkListItem>
     <LinkListItem disabled className="left-icon">
       <i className="it-chevron-right left" aria-hidden="true" />
-      <Icon icon="it-chevron-right" color="primary" />
+      <Icon
+        className="left"
+        color="primary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
       <span>Link list 3 disabled</span>
     </LinkListItem>
   </LinkList>
@@ -183,17 +214,32 @@ const ControlliSecondariComponent = () => (
     <LinkListItem active className="right-icon">
       <span>Link list 1 active</span>
       <i className="it-app right secondary" />
-      <Icon icon="it-link" color="primary" className="icon-right" />
+      <Icon
+        className="icon-right"
+        color="primary"
+        icon="it-link"
+        style={{ ariaHidden: true }}
+      />
     </LinkListItem>
     <LinkListItem className="right-icon">
       <span>Link list 2</span>
       <i className="it-app right secondary" />
-      <Icon icon="it-link" color="primary" className="icon-right" />
+      <Icon
+        className="icon-right"
+        color="primary"
+        icon="it-link"
+        style={{ ariaHidden: true }}
+      />
     </LinkListItem>
     <LinkListItem disabled className="right-icon">
       <span>Link list 3 disabled</span>
       <i className="it-app right secondary" />
-      <Icon icon="it-link" color="primary" className="icon-right" />
+      <Icon
+        className="icon-right"
+        color="primary"
+        icon="it-link"
+        style={{ ariaHidden: true }}
+      />
     </LinkListItem>
   </LinkList>
 )
@@ -202,21 +248,54 @@ const ControlliPrimariSecondariComponent = () => (
   <LinkList>
     <LinkListItem active className="left-icon right-icon">
       <i className="it-favorite left" />
-      <Icon icon="it-link" color="primary" />
+      <Icon
+        className="left"
+        color="primary"
+        icon="it-link"
+        style={{ ariaHidden: true }}
+      />
       <span>Link list 1 active</span>
       <i className="it-app right secondary" />
+      <Icon
+        className="right"
+        color="secondary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
     </LinkListItem>
     <LinkListItem className="left-icon right-icon">
       <i className="it-favorite left" />
-      <Icon icon="it-link" color="primary" />
+      <Icon
+        className="left"
+        color="primary"
+        icon="it-link"
+        style={{ ariaHidden: true }}
+      />
       <span>Link list 2</span>
       <i className="it-app right secondary" />
+      <Icon
+        className="right"
+        color="secondary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
     </LinkListItem>
     <LinkListItem disabled className="left-icon right-icon">
       <i className="it-favorite left" />
-      <Icon icon="it-link" color="primary" />
+      <Icon
+        className="left"
+        color="primary"
+        icon="it-link"
+        style={{ ariaHidden: true }}
+      />
       <span>Link list 3 disabled</span>
       <i className="it-app right secondary" />
+      <Icon
+        className="right"
+        color="secondary"
+        icon="it-chevron-right"
+        style={{ ariaHidden: true }}
+      />
     </LinkListItem>
   </LinkList>
 )

--- a/stories/LinkList/LinkListCollapsibleExample.js
+++ b/stories/LinkList/LinkListCollapsibleExample.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Collapse, LinkList, LinkListItem } from '../../src'
+import { Collapse, Icon, LinkList, LinkListItem } from '../../src'
 
 class CollapseExample extends React.Component {
   defaultState = {
@@ -34,9 +34,12 @@ class CollapseExample extends React.Component {
           {...(collapseOpen1 ? expanded : {})}>
           <span>Link list 1 </span>
           <i className="it-expand right" />
-          <svg className="icon icon-primary right">
-            <use xlinkHref="/svg/sprite.svg#it-expand"></use>
-          </svg>
+          <Icon
+            className="right"
+            color="primary"
+            icon="it-expand"
+            style={{ ariaHidden: true }}
+          />
         </LinkListItem>
         <Collapse isOpen={collapseOpen1}>
           <LinkList sublist>
@@ -58,9 +61,12 @@ class CollapseExample extends React.Component {
           {...(collapseOpen2 ? expanded : {})}>
           <span>Link list 2 </span>
           <i className="it-expand right" />
-          <svg className="icon icon-primary right">
-            <use xlinkHref="/svg/sprite.svg#it-expand"></use>
-          </svg>
+          <Icon
+            className="right"
+            color="primary"
+            icon="it-expand"
+            style={{ ariaHidden: true }}
+          />
         </LinkListItem>
         <Collapse isOpen={collapseOpen2}>
           <LinkList sublist>
@@ -82,9 +88,12 @@ class CollapseExample extends React.Component {
           {...(collapseOpen3 ? expanded : {})}>
           <span>Link list 3 </span>
           <i className="it-expand right" />
-          <svg className="icon icon-primary right">
-            <use xlinkHref="/svg/sprite.svg#it-expand"></use>
-          </svg>
+          <Icon
+            className="right"
+            color="primary"
+            icon="it-expand"
+            style={{ ariaHidden: true }}
+          />
         </LinkListItem>
         <Collapse isOpen={collapseOpen3}>
           <LinkList sublist>

--- a/stories/NavScroll/ComponenteMenuInline.js
+++ b/stories/NavScroll/ComponenteMenuInline.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
+import { Icon } from '../../src'
 
 class ComponenteMenuInline extends React.Component {
   render() {
@@ -48,9 +49,12 @@ class ComponenteMenuList extends React.Component {
           aria-controls="collapseOne"
           onClick={e => this.onNavScrollToggle(e)}>
           <span>Link list 1</span>
-          <svg className="icon icon-primary icon-sm">
-            <use xlinkHref="/svg/sprite.svg#it-expand"></use>
-          </svg>
+          <Icon
+            color="primary"
+            icon="it-expand"
+            style={{ ariaHidden: true }}
+            size="sm"
+          />
         </a>
         <ul
           className={

--- a/stories/NavScroll/PosizionamentoFondoPagina.js
+++ b/stories/NavScroll/PosizionamentoFondoPagina.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react'
+import { Icon } from '../../src'
 
 class PosizionamentoFondoPagina extends React.Component {
   state = {
@@ -61,9 +62,13 @@ class PosizionamentoFondoPagina extends React.Component {
                   : { display: 'none' }
               }
               onClick={this.onNavScrollToggle}>
-              <svg className="icon icon-sm icon-primary align-top">
-                <use xlinkHref="/svg/sprite.svg#it-chevron-left"></use>
-              </svg>
+              <Icon
+                className="align-top"
+                color="primary"
+                icon="it-chevron-left"
+                style={{ ariaHidden: true }}
+                size="sm"
+              />
               <span>Back </span>
             </a>
             <div className="menu-wrapper">

--- a/stories/NavScroll/PosizionamentoTestaAlla.js
+++ b/stories/NavScroll/PosizionamentoTestaAlla.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react'
+import { Icon } from '../../src'
 
 class PosizionamentoTestaAlla extends React.Component {
   state = {
@@ -61,9 +62,13 @@ class PosizionamentoTestaAlla extends React.Component {
                   : { display: 'none' }
               }
               onClick={this.onNavScrollToggle}>
-              <svg className="icon icon-sm icon-primary align-top">
-                <use xlinkHref="/svg/sprite.svg#it-chevron-left"></use>
-              </svg>
+              <Icon
+                className="align-top"
+                color="primary"
+                icon="it-chevron-left"
+                style={{ ariaHidden: true }}
+                size="sm"
+              />
               <span>Back </span>
             </a>
             <div className="menu-wrapper">

--- a/stories/Navbar/NavbarInlineExample.js
+++ b/stories/Navbar/NavbarInlineExample.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Collapse, LinkList, LinkListItem } from '../../src'
+import { Collapse, Icon, LinkList, LinkListItem } from '../../src'
 
 class NavbarInlineExample extends React.Component {
   defaultState = {
@@ -34,7 +34,11 @@ class NavbarInlineExample extends React.Component {
             onClick={e => this.toggle(e, 1)}
             {...(collapseOpen1 ? expanded : {})}>
             <span>Link list 1 </span>
-            <i className="it-expand right" />
+            <Icon
+              className="right"
+              icon="it-expand"
+              style={{ ariaHidden: true }}
+            />
           </LinkListItem>
           <Collapse isOpen={collapseOpen1}>
             <LinkList sublist>
@@ -55,7 +59,11 @@ class NavbarInlineExample extends React.Component {
             onClick={e => this.toggle(e, 2)}
             {...(collapseOpen2 ? expanded : {})}>
             <span>Link list 2 </span>
-            <i className="it-expand right" />
+            <Icon
+              className="right"
+              icon="it-expand"
+              style={{ ariaHidden: true }}
+            />
           </LinkListItem>
           <Collapse isOpen={collapseOpen2}>
             <LinkList sublist>
@@ -76,7 +84,11 @@ class NavbarInlineExample extends React.Component {
             onClick={e => this.toggle(e, 3)}
             {...(collapseOpen3 ? expanded : {})}>
             <span>Link list 3 </span>
-            <i className="it-expand right" />
+            <Icon
+              className="right"
+              icon="it-expand"
+              style={{ ariaHidden: true }}
+            />
           </LinkListItem>
           <Collapse isOpen={collapseOpen3}>
             <LinkList sublist>

--- a/stories/Pager/Pager.stories.js
+++ b/stories/Pager/Pager.stories.js
@@ -11,6 +11,7 @@ import {
   PagerLink,
   Form,
   FormGroup,
+  Icon,
   Input,
   Label
 } from '../../src'
@@ -33,7 +34,7 @@ const EsempiComponent = () => (
     <PagerList>
       <PagerItem>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem>
@@ -47,7 +48,7 @@ const EsempiComponent = () => (
       </PagerItem>
       <PagerItem>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -59,7 +60,7 @@ const StatoDisabilitatoAttivoComponent = () => (
     <PagerList>
       <PagerItem disabled>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem>
@@ -75,7 +76,7 @@ const StatoDisabilitatoAttivoComponent = () => (
       </PagerItem>
       <PagerItem disabled>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -88,7 +89,7 @@ const AllineamentoComponent = () => (
       <PagerList>
         <PagerItem disabled>
           <PagerLink previous href="#">
-            <i className="it-chevron-left" />
+            <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
           </PagerLink>
         </PagerItem>
         <PagerItem>
@@ -104,7 +105,7 @@ const AllineamentoComponent = () => (
         </PagerItem>
         <PagerItem>
           <PagerLink next href="#">
-            <i className="it-chevron-right" />
+            <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
           </PagerLink>
         </PagerItem>
       </PagerList>
@@ -114,7 +115,7 @@ const AllineamentoComponent = () => (
       <PagerList>
         <PagerItem disabled>
           <PagerLink previous href="#">
-            <i className="it-chevron-left" />
+            <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
           </PagerLink>
         </PagerItem>
         <PagerItem>
@@ -130,7 +131,7 @@ const AllineamentoComponent = () => (
         </PagerItem>
         <PagerItem>
           <PagerLink next href="#">
-            <i className="it-chevron-right" />
+            <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
           </PagerLink>
         </PagerItem>
       </PagerList>
@@ -143,7 +144,7 @@ const ResponsiveComponent = () => (
     <PagerList>
       <PagerItem>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem className="d-sm-block">
@@ -165,7 +166,7 @@ const ResponsiveComponent = () => (
       </PagerItem>
       <PagerItem>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -177,7 +178,7 @@ const MoreComponent = () => (
     <PagerList>
       <PagerItem>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem className="d-none d-sm-block">
@@ -211,7 +212,7 @@ const MoreComponent = () => (
       </PagerItem>
       <PagerItem>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -223,7 +224,7 @@ const ChangerComponent = () => (
     <PagerList>
       <PagerItem>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem className="d-none d-sm-block">
@@ -257,7 +258,7 @@ const ChangerComponent = () => (
       </PagerItem>
       <PagerItem>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -284,7 +285,7 @@ const JumpComponent = () => (
     <PagerList>
       <PagerItem>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem className="d-none d-sm-block">
@@ -318,7 +319,7 @@ const JumpComponent = () => (
       </PagerItem>
       <PagerItem>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -331,7 +332,7 @@ const SimpleComponent = () => (
     <PagerList>
       <PagerItem disabled>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem className="d-none d-sm-block">
@@ -345,7 +346,7 @@ const SimpleComponent = () => (
       </PagerItem>
       <PagerItem>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -403,7 +404,7 @@ const TotalComponent = () => (
     <PagerList>
       <PagerItem>
         <PagerLink previous href="#">
-          <i className="it-chevron-left" />
+          <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
       <PagerItem className="d-none d-sm-block">
@@ -437,7 +438,7 @@ const TotalComponent = () => (
       </PagerItem>
       <PagerItem>
         <PagerLink next href="#">
-          <i className="it-chevron-right" />
+          <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
         </PagerLink>
       </PagerItem>
     </PagerList>
@@ -464,7 +465,7 @@ const EsempiInterattiviComponent = () => {
       <PagerList>
         <PagerItem disabled={disabled}>
           <PagerLink {...current} previous href="#">
-            <i className="it-chevron-left" />
+            <Icon icon="it-chevron-left" style={{ ariaHidden: true }} />
           </PagerLink>
         </PagerItem>
         <PagerItem disabled={disabled}>
@@ -474,7 +475,7 @@ const EsempiInterattiviComponent = () => {
         </PagerItem>
         <PagerItem disabled={disabled}>
           <PagerLink {...current} next href="#">
-            <i className="it-chevron-right" />
+            <Icon icon="it-chevron-right" style={{ ariaHidden: true }} />
           </PagerLink>
         </PagerItem>
       </PagerList>

--- a/stories/Popover/PopoverIconLink.js
+++ b/stories/Popover/PopoverIconLink.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Popover, PopoverHeader, PopoverBody } from '../../src'
+import { Icon, Popover, PopoverHeader, PopoverBody } from '../../src'
 
 class PopoverIconLink extends React.Component {
   state = {
@@ -37,9 +37,11 @@ class PopoverIconLink extends React.Component {
           isOpen={this.state.popoverOpen}
           toggle={this.togglePopover}>
           <PopoverHeader>
-            <svg className="icon icon-white">
-              <use xlinkHref="/svg/sprite.svg#it-help-circle" />
-            </svg>{' '}
+            <Icon
+              color="white"
+              icon="it-help-circle"
+              style={{ ariaHidden: true }}
+            />
             Titolo con icona
           </PopoverHeader>
           <PopoverBody>
@@ -47,9 +49,7 @@ class PopoverIconLink extends React.Component {
             finibus augue.
             <a href="#" className="popover-inner-link">
               More info
-              <svg className="icon">
-                <use xlinkhref="/bootstrap-italia/dist/svg/sprite.svg#it-arrow-right" />
-              </svg>
+              <Icon icon="it-arrow-right" style={{ ariaHidden: true }} />
             </a>
           </PopoverBody>
         </Popover>

--- a/stories/Progress/Progress.stories.js
+++ b/stories/Progress/Progress.stories.js
@@ -4,7 +4,7 @@ import { withKnobs, number, text, select } from '@storybook/addon-knobs/react'
 import { withA11y } from '@storybook/addon-a11y'
 import { withInfo } from '@storybook/addon-info'
 
-import { Progress, Button, Spinner } from '../../src'
+import { Button, Icon, Progress, Spinner } from '../../src'
 
 import Esempi from './docs/Esempi.md'
 import Etichette from './docs/Etichette.md'
@@ -71,9 +71,7 @@ const ButtonProgressComponent = () => (
         </p>
         <Button color="primary" className="btn-progress" disabled>
           Label bottone{' '}
-          <svg className="icon icon-light">
-            <use xlinkHref="/svg/sprite.svg#it-github" />
-          </svg>
+          <Icon color="light" icon="it-github" style={{ ariaHidden: true }} />
           <span>
             <Progress value="50" />
           </span>
@@ -85,9 +83,7 @@ const ButtonProgressComponent = () => (
         </p>
         <Button color="secondary" className="btn-progress" disabled>
           Label bottone{' '}
-          <svg className="icon icon-light">
-            <use xlinkHref="/svg/sprite.svg#it-github" />
-          </svg>
+          <Icon color="light" icon="it-github" style={{ ariaHidden: true }} />
           <span>
             <Progress value="50" />
           </span>

--- a/stories/Sidebar/Sidebar.stories.js
+++ b/stories/Sidebar/Sidebar.stories.js
@@ -10,7 +10,7 @@ import ConLineaSinistra from './docs/ConLineaSinistra.md'
 import Annidata from './docs/Annidata.md'
 import ScuraSidebar from './docs/ScuraSidebar.md'
 
-import { LinkList, LinkListItem, Sidebar } from '../../src'
+import { LinkList, LinkListItem, Sidebar, Icon } from '../../src'
 
 import SidebarCollapseExample from './SidebarCollapsibleExample'
 
@@ -62,31 +62,43 @@ const ConIconaSidebarComponent = () => (
     <LinkList>
       <LinkListItem header>HEADER</LinkListItem>
       <LinkListItem medium active className="left-icon">
-        <i className="it-chevron-right left" aria-hidden="true" />
-        <svg className="icon icon-sm left">
-          <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-        </svg>
+        <Icon
+          className="left"
+          icon="it-chevron-right"
+          color=""
+          style={{ ariaHidden: true }}
+          size="sm"
+        />
         <span>Link list active</span>
       </LinkListItem>
       <LinkListItem medium disabled>
-        <i className="it-chevron-right left" aria-hidden="true" />
-        <svg className="icon icon-sm left">
-          <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-        </svg>
+        <Icon
+          className="left"
+          icon="it-chevron-right"
+          color=""
+          style={{ ariaHidden: true }}
+          size="sm"
+        />
         <span>Link list disabled</span>
       </LinkListItem>
       <LinkListItem medium>
-        <i className="it-chevron-right left" aria-hidden="true" />
-        <svg className="icon icon-sm left">
-          <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-        </svg>
+        <Icon
+          className="left"
+          icon="it-chevron-right"
+          color=""
+          style={{ ariaHidden: true }}
+          size="sm"
+        />
         <span>Link list</span>
       </LinkListItem>
       <LinkListItem medium>
-        <i className="it-chevron-right left" aria-hidden="true" />
-        <svg className="icon icon-sm left">
-          <use xlinkHref="/svg/sprite.svg#it-star-outline" />
-        </svg>
+        <Icon
+          className="left"
+          icon="it-chevron-right"
+          color=""
+          style={{ ariaHidden: true }}
+          size="sm"
+        />
         <span>Link list</span>
       </LinkListItem>
     </LinkList>

--- a/stories/Sidebar/SidebarCollapsibleExample.js
+++ b/stories/Sidebar/SidebarCollapsibleExample.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Collapse, LinkList, LinkListItem, Sidebar } from '../../src'
+import { Collapse, LinkList, LinkListItem, Sidebar, Icon } from '../../src'
 
 class SidebarCollapseExample extends React.Component {
   defaultState = {
@@ -34,10 +34,12 @@ class SidebarCollapseExample extends React.Component {
             onClick={e => this.toggle(e, 1)}
             {...(collapseOpen1 ? expanded : {})}>
             <span>Link list 1 </span>
-            <i className="it-expand right" />
-            <svg className="icon icon-primary right">
-              <use xlinkHref="/svg/sprite.svg#it-expand" />
-            </svg>
+            <Icon
+              className="right"
+              icon="it-expand"
+              color="primary"
+              style={{ ariaHidden: true }}
+            />
           </LinkListItem>
           <Collapse isOpen={collapseOpen1}>
             <LinkList sublist>
@@ -58,10 +60,12 @@ class SidebarCollapseExample extends React.Component {
             onClick={e => this.toggle(e, 2)}
             {...(collapseOpen2 ? expanded : {})}>
             <span>Link list 2 </span>
-            <i className="it-expand right" />
-            <svg className="icon icon-primary right">
-              <use xlinkHref="/svg/sprite.svg#it-expand" />
-            </svg>
+            <Icon
+              className="right"
+              icon="it-expand"
+              color="primary"
+              style={{ ariaHidden: true }}
+            />
           </LinkListItem>
           <Collapse isOpen={collapseOpen2}>
             <LinkList sublist>
@@ -82,10 +86,12 @@ class SidebarCollapseExample extends React.Component {
             onClick={e => this.toggle(e, 3)}
             {...(collapseOpen3 ? expanded : {})}>
             <span>Link list 3 </span>
-            <i className="it-expand right" />
-            <svg className="icon icon-primary right">
-              <use xlinkHref="/svg/sprite.svg#it-expand" />
-            </svg>
+            <Icon
+              className="right"
+              icon="it-expand"
+              color="primary"
+              style={{ ariaHidden: true }}
+            />
           </LinkListItem>
           <Collapse isOpen={collapseOpen3}>
             <LinkList sublist>

--- a/stories/Tab/TabExample.js
+++ b/stories/Tab/TabExample.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Nav, NavItem, NavLink, TabContent, TabPane } from '../../src'
+import { Icon, Nav, NavItem, NavLink, TabContent, TabPane } from '../../src'
 import PropTypes from 'prop-types'
 
 const titles = ['Tab titolo 1', 'Tab titolo 2', 'Tab titolo 3']
@@ -33,9 +33,11 @@ class TabExample extends React.Component {
                 if (icons) {
                   return (
                     <span>
-                      <svg className="icon icon-primary">
-                        <use xlinkHref="/svg/sprite.svg#it-link"></use>
-                      </svg>
+                      <Icon
+                        color="primary"
+                        icon="it-link"
+                        style={{ ariaHidden: true }}
+                      />
                       <i
                         className="it-ico-lg it-file d-block text-center"
                         aria-label={titles[0]}
@@ -62,9 +64,11 @@ class TabExample extends React.Component {
                 if (icons) {
                   return (
                     <span>
-                      <svg className="icon icon-primary">
-                        <use xlinkHref="/svg/sprite.svg#it-calendar"></use>
-                      </svg>
+                      <Icon
+                        color="primary"
+                        icon="it-calendar"
+                        style={{ ariaHidden: true }}
+                      />
                       <i
                         className="it-ico-lg it-calendar d-block text-center"
                         aria-label={titles[1]}
@@ -91,9 +95,11 @@ class TabExample extends React.Component {
                 if (icons) {
                   return (
                     <span>
-                      <svg className="icon icon-primary">
-                        <use xlinkHref="/svg/sprite.svg#it-comment"></use>
-                      </svg>
+                      <Icon
+                        color="primary"
+                        icon="it-comment"
+                        style={{ ariaHidden: true }}
+                      />
                       <i
                         className="it-ico-lg it-comment d-block text-center"
                         aria-label={titles[2]}


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #388 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
Refactors stories where either the Icon component uses an old props format or an svg is used in place of a component. 

#### Changes proposed in this pull request:

- Replace an svg with the Icon component where an icon is needed in the stories.


