### PR TITLE
Fix SSR by checking browser environment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
-import WebFont from 'webfontloader'
+if (typeof window !== 'undefined') {
+  const WebFont = require('webfontloader')
 
-WebFont.load({
-  custom: {
-    families: [
-      'Titillium Web:300,400,600,700:latin-ext',
-      'Lora:400,700:latin-ext',
-      'Roboto Mono:400,700:latin-ext'
-    ]
-  }
-})
+  WebFont.load({
+    custom: {
+      families: [
+        'Titillium Web:300,400,600,700:latin-ext',
+        'Lora:400,700:latin-ext',
+        'Roboto Mono:400,700:latin-ext'
+      ]
+    }
+  })
+}
 
 export {
   Alert,


### PR DESCRIPTION

Fixes #473 

#### PR Checklist

- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Skip the font loading check on non-browser environments for SSR builds.

#### Changes proposed in this pull request:
- Check `window` environment


