### PR TITLE
Tag prop into CardReadMore

### DIFF
--- a/src/components/Card/CardReadMore.js
+++ b/src/components/Card/CardReadMore.js
@@ -10,16 +10,12 @@ const propTypes = {
   iconName: PropTypes.string,
   href: PropTypes.string,
   text: PropTypes.string,
-  tag: tagPropType,
-  to: PropTypes.string
-}
-
-const defaultTypes = {
-  iconName: 'it-arrow-right'
+  tag: tagPropType
 }
 
 const defaultProps = {
-  tag: 'a'
+  tag: 'a',
+  iconName: 'it-arrow-right'
 }
 
 const CardReadMore = props => {
@@ -34,7 +30,6 @@ const CardReadMore = props => {
 }
 
 CardReadMore.propTypes = propTypes
-CardReadMore.defaultTypes = defaultTypes
 CardReadMore.defaultProps = defaultProps
 
 export default CardReadMore

--- a/src/components/Card/CardReadMore.js
+++ b/src/components/Card/CardReadMore.js
@@ -3,30 +3,38 @@ import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
 import Icon from '../Icon/Icon'
+import tagPropType from 'reactstrap/src/utils'
 
 const propTypes = {
   className: PropTypes.string,
   iconName: PropTypes.string,
   href: PropTypes.string,
-  text: PropTypes.string
+  text: PropTypes.string,
+  tag: tagPropType,
+  to: PropTypes.string
 }
 
 const defaultTypes = {
   iconName: 'it-arrow-right'
 }
 
+const defaultProps = {
+  tag: 'a'
+}
+
 const CardReadMore = props => {
-  const { className, text, iconName, ...attributes } = props
+  const { className, text, iconName, tag: Tag, href, ...attributes } = props
   const classes = classNames(className, 'read-more')
   return (
-    <a className={classes} {...attributes}>
+    <Tag className={classes} href={href} {...attributes}>
       <span className="text">{text}</span>
       {iconName && <Icon icon={iconName} />}
-    </a>
+    </Tag>
   )
 }
 
 CardReadMore.propTypes = propTypes
 CardReadMore.defaultTypes = defaultTypes
+CardReadMore.defaultProps = defaultProps
 
 export default CardReadMore

--- a/stories/Card/Card.stories.js
+++ b/stories/Card/Card.stories.js
@@ -290,6 +290,7 @@ const EsempiInterattiviComponent = () => {
             <CardReadMore
               iconName="it-arrow-right"
               text="Leggi di più"
+              tag={'a'}
               href={linkOption}
             />
           </CardBody>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #465 
Make CardReadMore support the tag prop.

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
CardReadMore wraps a link component. Many frameworks and/or libraries, like React Router or Next.js, usually provide their own link component to be used for the client-side routing.

The NavLink, as reference, supports the tag prop in a way that makes easier to integrate with other components.

#### Changes proposed in this pull request:

- I have updated CardReadMore.js file. This component now supports the tag prop. The tag passed in the props of this component will be used for rendering it.
- I have updated Card.stories.js also. In it, I have changed 'EsempiInterattiviComponent' component by adding the tag prop to its CardReadMore component.


