### PR TITLE
Add support for date and Icon

### DIFF
--- a/src/components/Card/CardCategory.js
+++ b/src/components/Card/CardCategory.js
@@ -14,7 +14,7 @@ const CardCategory = props => {
   const { iconName, date, href, ...attributes } = props
   const { children, ...rest } = attributes
   const classes = classNames({
-    'category-top': !iconName,
+    'category-top': date || ' ',
     'categoryicon-top': iconName
   })
   // Simple category link
@@ -23,7 +23,7 @@ const CardCategory = props => {
       {children}
     </a>
   )
-  const categoryDate = !iconName && <span className="data">{date}</span>
+  const categoryDate = date && <span className="data">{date}</span>
   // Category with icon
   const categoryText = iconName && <span className="text">{children}</span>
   const categoryIcon = iconName && <Icon icon={iconName} />
@@ -31,9 +31,9 @@ const CardCategory = props => {
   return (
     <div className={classes} {...rest}>
       {categoryLink}
-      {categoryDate}
       {categoryIcon}
       {categoryText}
+      {categoryDate}
     </div>
   )
 }

--- a/stories/Card/Card.stories.js
+++ b/stories/Card/Card.stories.js
@@ -93,6 +93,31 @@ const SimpleArticleComponent = () => (
   </div>
 )
 
+const SimpleArticleDateIconComponent = () => (
+  <div className="row">
+    <div className="col-12 col-lg-6">
+      {/* start card */}
+      <Card>
+        <CardBody>
+          <CardCategory date="10/12/2018" iconName="it-calendar">
+            Category
+          </CardCategory>
+          <CardTitle tag="h5" className="big-heading">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit…
+          </CardTitle>
+          <CardText>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          </CardText>
+          <CardSignature>di Federico De Paolis</CardSignature>
+          <CardReadMore text="Leggi di più" iconName="it-arrow-right" />
+        </CardBody>
+      </Card>
+      {/* end card */}
+    </div>
+  </div>
+)
+
 const CardIconComponent = () => (
   <div className="row">
     <div className="col-12 col-lg-6">
@@ -325,6 +350,13 @@ storiesOf('Componenti/Cards', module)
       text: SimpleArticle,
       propTables: [Card]
     })(SimpleArticleComponent)
+  )
+  .add(
+    'Simple Article with Icon',
+    withInfo({
+      text: SimpleArticle,
+      propTables: [Card, CardCategory]
+    })(SimpleArticleDateIconComponent)
   )
   .add(
     'Card with icon',


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #526 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:
While working with gatsby starter, there was a scenario where both icon and date were required.
`CardCategory` could support either `date` or `iconName` but not both.

#### Changes proposed in this pull request:

- `CardCategory` can have `date`, `iconName`, both or nothing.
- Added a story `Simple Article with Icon` to visualize this change.


