### PR TITLE
Enable tree-shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 
 # Outputs
 storybook-static
+dist/
+
 
 # Logs
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
     "author": "Presidenza del Consiglio dei Ministri",
     "homepage": "https://github.com/italia/design-react-kit#README",
     "license": "BSD-3-Clause",
-    "module": "dist/design-react-kit",
-    "typings": "dist/design-react-kit",
+    "sideEffects": false,
+    "main": "dist/design-react-kit.js",
+    "module": "dist/design-react-kit.es.js",
+    "typings": "dist/design-react-kit.d.ts",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/italia/design-react-kit.git"


### PR DESCRIPTION
#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Hey, since this library is ~300KB I think tree-shaking is necessary.

Tree-shaking lets the developer using this library include into the final bundle only the components he is actually using. It works by setting the property `sideEffects` to `false` in the `package.json`, acknowledging that is not doing anything in the javascript global world (things like polyfills), rather is just exporting self-container components. [More info in the Webpack documentation](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).

[Reactstrap is already doing this](https://github.com/reactstrap/reactstrap/blob/e1915e87970fb22ae9ebd89ccc13b61b0b856000/package.json#L12).


#### Short description of what this resolves:
- `npx create-react-app test-app`
- `cd test-app`
- `yarn add design-react-kit`

And replace the `src/App.js` with the design-react-kit basic example
```js
import React from 'react';
import { Alert } from 'design-react-kit';

function App() {
  return (
    <Alert>This is an Alert</Alert>
  );
}

export default App;
```

When then running `yarn build` the vendors.js file is ~400KB because it contains every component exported from this repo and not actually used.


<img width="285" alt="Screenshot 2020-05-12 at 16 56 08" src="https://user-images.githubusercontent.com/7217420/81709904-895d5800-9472-11ea-8ed3-b09fa302a1d6.png">




#### Changes proposed in this pull request:

With this PR the vendor bundle contains only the used components: 

<img width="268" alt="Screenshot 2020-05-12 at 17 01 07" src="https://user-images.githubusercontent.com/7217420/81710026-ad209e00-9472-11ea-9d53-86fb4ff30e3b.png">

-------------

Also I added the `dist/` folder to the .gitignore because otherwise git would see new files each time the library is built.