### PR TITLE
Replace xlinkHref with href

### DIFF
--- a/src/components/Icon/Icon.js
+++ b/src/components/Icon/Icon.js
@@ -31,7 +31,7 @@ const Icon = ({ color, size, icon, className, padding, ...attributes }) => {
   )
   return (
     <svg className={classes} {...attributes}>
-      <use xlinkHref={`${iconSprite}#${icon}`} />
+      <use href={`${iconSprite}#${icon}`} />
     </svg>
   )
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Hey, we just had a big bug with some static rendering where `xlinkHref` would actually be output as `xlinkHref` in the dom instead of `xlink:href`, so the icons would not be shown.

Then I realized, that attribute is actually [deprecated and should not be used anymore](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href)!

#### Changes proposed in this pull request:
Use the `href` attribute instead, it has basically [the same browser support](https://caniuse.com/#feat=mdn-svg_elements_use_href) as the [xlink:href attribute](https://caniuse.com/#feat=mdn-svg_elements_use_xlink_href)


[Read more about the attributes of the `use` tag](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use)