### PR TITLE
Add browserslist config and documentation

### DIFF
--- a/README.EN.md
+++ b/README.EN.md
@@ -167,8 +167,9 @@ $ yarn build
 
 ## Browsers support
 
-In the Developers Italia documentation, within the Section [6.3.1.2.1. Supporto browser](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/2020.1/doc/user-interface/lo-sviluppo-di-un-interfaccia-e-i-web-kit.html#strumenti), there's a list of supported browsers for this Design Kit.
+As stated on the Guidelines for Public Services Design, within the Section [6.3.1.2.1. Supporto browser](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/2020.1/doc/user-interface/lo-sviluppo-di-un-interfaccia-e-i-web-kit.html#strumenti), here's a list of supported browsers for this Design Kit.
 The list is here available in the `browserslist` format:
+
 ```json
 "browserslist": [
     "defaults",
@@ -180,8 +181,7 @@ The list is here available in the `browserslist` format:
 ]
 ```
 
-The same list is also available in the `package.json` of this `design-react-kit`.
-It's not possible yet to extends this `browserslist` configuration for [security concerns](https://github.com/browserslist/browserslist#shareable-configs).
+The same list is also available in the `package.json` file. Unfortunately, it's not possible to extend this `browserslist` configuration yet for [security concerns](https://github.com/browserslist/browserslist#shareable-configs).
 
 ## TypeScript typing definitions 
 

--- a/README.EN.md
+++ b/README.EN.md
@@ -165,6 +165,24 @@ To build the library and add files into the `dist` folder:
 $ yarn build
 ```
 
+## Browserrs support
+
+In the Developers Italia documentation, within the Section [6.3.1.2.1. Supporto browser](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/2020.1/doc/user-interface/lo-sviluppo-di-un-interfaccia-e-i-web-kit.html#strumenti), there's a list of supported browsers for this Design Kit.
+The list is here available in the `browserslist` format:
+```json
+"browserslist": [
+    "defaults",
+    "ie 11",
+    "not ie_mob 11",
+    "not op_mini all",
+    "edge >= 13",
+    "safari 11"
+]
+```
+
+The same list is also available in the `package.json` of this `design-react-kit`.
+It's not possible yet to extends this `browserslist` configuration for [security concerns](https://github.com/browserslist/browserslist#shareable-configs).
+
 ## TypeScript typing definitions 
 
 To generate Typescript typing definitions file:

--- a/README.EN.md
+++ b/README.EN.md
@@ -165,7 +165,7 @@ To build the library and add files into the `dist` folder:
 $ yarn build
 ```
 
-## Browserrs support
+## Browsers support
 
 In the Developers Italia documentation, within the Section [6.3.1.2.1. Supporto browser](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/2020.1/doc/user-interface/lo-sviluppo-di-un-interfaccia-e-i-web-kit.html#strumenti), there's a list of supported browsers for this Design Kit.
 The list is here available in the `browserslist` format:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ Per compilare la libreria e generare i file nella cartella `dist`, è sufficient
 $ yarn build
 ```
 
+## Supporto browsers
+
+Nella documentazione Developers Italia, nella sezione [6.3.1.2.1. Supporto browser](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/2020.1/doc/user-interface/lo-sviluppo-di-un-interfaccia-e-i-web-kit.html#strumenti), è indicata la lista dei browser supportata dal Design Kit.
+La lista è qui disponibile nel formato `browserslist`:
+```json
+"browserslist": [
+    "defaults",
+    "ie 11",
+    "not ie_mob 11",
+    "not op_mini all",
+    "edge >= 13",
+    "safari 11"
+]
+```
+
+La lista è anche disponibile nel `package.json` di questo `design-react-kit`, per comodità.
+Non è ancora possibile estendere la lista di questo pacchetto per [problematiche di sicurezza](https://github.com/browserslist/browserslist#shareable-configs).
+
 ## TypeScript typings 
 
 Per generare il file delle definizioni per i _typing_ Typescript, è sufficiente lanciare il comando dedicato:

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ $ yarn build
 
 ## Supporto browsers
 
-Nella documentazione Developers Italia, nella sezione [6.3.1.2.1. Supporto browser](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/2020.1/doc/user-interface/lo-sviluppo-di-un-interfaccia-e-i-web-kit.html#strumenti), è indicata la lista dei browser supportata dal Design Kit.
-La lista è qui disponibile nel formato `browserslist`:
+Come da indicazioni riportate nelle Linee Guida di Design per i servizi web della Pubblica Amministrazione, sezione [6.3.1.2.1. Supporto browser](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/2020.1/doc/user-interface/lo-sviluppo-di-un-interfaccia-e-i-web-kit.html#strumenti), di seguito è indicata la lista dei browser supportata dal Design Kit, disponibile nel formato `browserslist`:
+
 ```json
 "browserslist": [
     "defaults",
@@ -177,8 +177,7 @@ La lista è qui disponibile nel formato `browserslist`:
 ]
 ```
 
-La lista è anche disponibile nel `package.json` di questo `design-react-kit`, per comodità.
-Non è ancora possibile estendere la lista di questo pacchetto per [problematiche di sicurezza](https://github.com/browserslist/browserslist#shareable-configs).
+La lista è anche disponibile nel `package.json`. Purtroppo, non è ancora possibile estendere la lista di questo pacchetto per [problematiche di sicurezza](https://github.com/browserslist/browserslist#shareable-configs).
 
 ## TypeScript typings 
 

--- a/package.json
+++ b/package.json
@@ -113,5 +113,13 @@
         "react-transition-group": "^2.3.1",
         "reactstrap": "^8.0.0",
         "webfontloader": "^1.6.28"
-    }
+    },
+    "browserslist": [
+        "defaults",
+        "ie 11",
+        "not ie_mob 11",
+        "not op_mini all",
+        "edge >= 13",
+        "safari 11"
+    ]
 }


### PR DESCRIPTION
Fixes #574 

#### PR Checklist
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

This PR adds some doc about supported browsers, relative to the Developers Italia documentation.

#### Changes proposed in this pull request:

- :wrench: Add `browserslist` config
- :pencil: Add instructions to use it
- :globe_with_meridians: Add instructions in EN


