### PR TITLE
Fix TS dts script issue with missing folder

### DIFF
--- a/scripts/dts.js
+++ b/scripts/dts.js
@@ -1,5 +1,5 @@
 const dtsgen = require('react-to-typescript-definitions')
-const writeFileSync = require('fs').writeFileSync
+const { writeFileSync, existsSync, mkdirSync } = require('fs')
 const path = require('path')
 const glob = require('glob')
 
@@ -31,6 +31,10 @@ const mainModule = [
   }),
   '}'
 ].join('\n')
+
+if (!existsSync('./dist')) {
+  mkdirSync('./dist')
+}
 
 writeFileSync(
   './dist/design-react-kit.d.ts',


### PR DESCRIPTION
Since #542 the `dist` folder is gone by default, so the TS dts script was broken as well.
This PR addresses this issue by checking the existence of the folder, and creating it when missing.


#### Changes proposed in this pull request:

- :bug: Fix dts creation script


