### PR TITLE
Fix SSR builds

### DIFF
--- a/src/components/Forward/Forward.js
+++ b/src/components/Forward/Forward.js
@@ -2,6 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
+// SSR does have no access to the Element global variable, so mock it
+if (typeof window === 'undefined') {
+  global.Element = typeof Element === 'undefined' ? function() {} : Element
+}
+
 const propTypes = {
   className: PropTypes.string,
   scrollToRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })


### PR DESCRIPTION
This PR fixes a reegreession introduced with #505 that broke the SSR build.

Fixes #577 

I tested locally a Gatsby instance with this PR version:
```sh
$ yarn build
yarn run v1.22.4
$ gatsby build
success open and validate gatsby-configs - 0.028s
success load plugins - 0.840s
success onPreInit - 0.077s
success delete html and css files from previous builds - 0.008s
success initialize cache - 0.005s
success copy gatsby files - 0.073s
success onPreBootstrap - 0.018s
success createSchemaCustomization - 0.007s
success Checking for changed pages - 0.003s
success source and transform nodes - 0.089s
success building schema - 0.268s
info Total nodes: 45, SitePage nodes: 1 (use --verbose for breakdown)
success createPages - 0.005s
success Checking for changed pages - 0.002s
success createPagesStatefully - 0.074s
success Cleaning up stale page-data - 0.003s
success update schema - 0.023s
success onPreExtractQueries - 0.001s
success extract queries from components - 0.241s
success write out redirect data - 0.002s
success Build manifest and related icons - 0.068s
success onPostBootstrap - 0.073s
info bootstrap finished - 6.943s
success run static queries - 0.023s - 1/1 43.48/s
success run page queries - 0.015s - 8/8 537.62/s
success write out requires - 0.006s
success Building production JavaScript and CSS bundles - 10.536s
success Building static HTML for pages - 2.788s - 8/8 2.87/s
success onPostBuild - 0.002s
info Done building in 20.448 sec
✨  Done in 20.68s.
```


