### PR TITLE
Bump node version to fix SSR job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ aliases:
 defaults: &defaults
   docker:
     # specify the version you desire here
-    - image: circleci/node:10
+    - image: circleci/node:12
 
   working_directory: *working_directory
 


### PR DESCRIPTION
Fixes #685 

#### Short description of what this resolves:

Bump the node version of the docker image used in Circle CI to make it work again the SSR check.

#### Changes proposed in this pull request:

- :arrow_up: Bump node version


