### PR TITLE
CI check tree shaking

### DIFF
--- a/.github/workflows/check-tree-shakeability.yml
+++ b/.github/workflows/check-tree-shakeability.yml
@@ -1,0 +1,32 @@
+name: Check tree-shakeability
+on: [ pull_request ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build artifacts
+        run: yarn build
+
+      - name: Run agadoo
+        id: agadoo
+        run: npx agadoo

--- a/.github/workflows/check-tree-shakeability.yml
+++ b/.github/workflows/check-tree-shakeability.yml
@@ -3,6 +3,8 @@ on: [ pull_request ]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js

--- a/.github/workflows/check-tree-shakeability.yml
+++ b/.github/workflows/check-tree-shakeability.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/check-tree-shakeability.yml
+++ b/.github/workflows/check-tree-shakeability.yml
@@ -27,6 +27,40 @@ jobs:
       - name: Build artifacts
         run: yarn build
 
+      - name: Install agadoo
+        # TODO decide if agadoo will be installed as a project dependency or just in CI
+        run: npm install -g agadoo
       - name: Run agadoo
         id: agadoo
-        run: npx agadoo
+        run: |
+          # Run Agadoo and store the output for further usage
+          # We store the process stdout and stderr to tmp files
+          STDOUT_F=$(mktemp)
+          STDERR_F=$(mktemp)
+          # Run agadoo and capture errors without breaking the workflow
+          (agadoo 2> $STDERR_F > $STDOUT_F || RET=$? && RET=$? ) ||:
+
+          # In order to be used in GH actions `echo "::set-output` the
+          # multi-line output must be escaped.
+          STDOUT="$(cat $STDOUT_F)"
+          STDOUT="${STDOUT//'%'/%25}"
+          STDOUT="${STDOUT//$'\n'/%0A}"
+          STDOUT="${STDOUT//$'\r'/%0D}"
+          STDERR="$(cat $STDERR_F)"
+          STDERR="${STDERR//'%'/%25}"
+          STDERR="${STDERR//$'\n'/%0A}"
+          STDERR="${STDERR//$'\r'/%0D}"
+          echo "::set-output name=stdout::$STDOUT"
+          echo "::set-output name=stderr::$STDERR"
+          if [[ $RET ]]; then
+            echo "::set-output name=status::tree-shakeable"
+          else
+            echo "::set-output name=status::not tree-shakeable"
+          fi
+          echo "::group::Agadoo output"
+          echo "$STDOUT"
+          echo "::endgroup::"
+          # Clean-up
+          rm $STDOUT_F
+          rm $STDERR_F
+          exit 0

--- a/.github/workflows/check-tree-shakeability.yml
+++ b/.github/workflows/check-tree-shakeability.yml
@@ -57,10 +57,35 @@ jobs:
           else
             echo "::set-output name=status::not tree-shakeable"
           fi
-          echo "::group::Agadoo output"
           echo "$STDOUT"
-          echo "::endgroup::"
+          echo ""
+          echo "$STDERR"
           # Clean-up
           rm $STDOUT_F
           rm $STDERR_F
           exit 0
+      - name: comment PR
+        uses: unsplash/comment-on-pr@v1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: |
+            **Check tree-shakeability** :deciduous_tree: for ${{ github.sha }}: ${{ steps.agadoo.outputs.status }}
+            <details>
+              <summary>Agadoo stdout</summary>
+
+              ```javascript
+              ${{ steps.agadoo.outputs.stdout }}
+              ```
+
+            </details>
+            <details>
+              <summary>Agadoo stderr</summary>
+
+              ```javascript
+              ${{ steps.agadoo.outputs.stderr }}
+              ```
+
+            </details>
+          check_for_duplicate_msg: false
+          delete_prev_regex_msg: "**Check tree-shakeability** :deciduous_tree: "


### PR DESCRIPTION
Hello, here's my implementation of https://github.com/italia/design-react-kit/issues/733 using GitHub actions.
I still have some doubts about the implementation that, I think, are worth discussing:

- I've used an external action `unsplash/comment-on-pr@v1.3.0` is this OK or should I implement the functionality locally?
- The output of `agadoo` is quite long and doesn't fit the limit on comment length imposed by GitHub. One way to circumvent this problem would be to upload the result as an `artifact`(https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts) and point the reader to it in the comment or, alternatively, split the result over multiple comments.

Let me know what you think, have a nice day!

Fixes #

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [ ] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
<!-- Please add a short description of what this PR resolves to be clear for the community. -->
This PR adds a CI job to check treeshake state of the library using GitHub actions.

#### Changes proposed in this Pull Request:
<!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
- set-up a GitHub action to run `agadoo` on pull requests
- post the result as a comment on the PR
