### PR TITLE
refactor: omit unsued props in Rating component

### DIFF
--- a/src/Rating/Rating.tsx
+++ b/src/Rating/Rating.tsx
@@ -7,20 +7,18 @@ import type { InputProps } from '../Input/Input';
 import { Icon } from '../Icon/Icon';
 import { noop } from '../utils';
 
-interface FilteredInputProps extends Omit<InputProps, 
-'bsSize' |
-'size' |
-'static' |
-'plaintext' |
-'normalized' |
-'addon' |
-'placeholder' |
-'label' |
-'value' |
-'type'
-> {}
-
-export interface RatingProps extends FilteredInputProps {
+type UnusedProps =
+  | 'bsSize'
+  | 'size'
+  | 'static'
+  | 'plaintext'
+  | 'normalized'
+  | 'addon'
+  | 'placeholder'
+  | 'label'
+  | 'value'
+  | 'type';
+export interface RatingProps extends Omit<InputProps, UnusedProps> {
   /** La lista di 5 id, per ciascun elemento intero del Rating. La lista deve essere ordinata dal rating 1 al rating 5.  */
   inputs: string[];
   /** Il campo "label" è impostato di default su "Valuta ${n} stelle su 5", ma può essere personalizzato con questa funzione che riceve il numero input come argomento `function (n: number) => string`. */


### PR DESCRIPTION
Fixes #763 

#### PR Checklist

- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Remove ineffective props from `Rating` component that were wrongly inherited from the `InputProps`

#### Changes proposed in this Pull Request:

- omitted the unused props identified in #763 
