### PR TITLE
Updated Reactstrap URLs in doc (should fix #783)

### DIFF
--- a/stories/Breadcrumb/Breadcrumb.stories.mdx
+++ b/stories/Breadcrumb/Breadcrumb.stories.mdx
@@ -60,4 +60,4 @@ Per la versione su sfondo scuro delle breadcrumbs è sufficiente aggiungere l'at
 
 <ArgsTable of={Breadcrumb} />
 
-Per ulteriori informazioni sui breadcrumbs si rimanda alla sezione `breadcrumbs` del sito [Reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/breadcrumbs/).
+Per ulteriori informazioni sui breadcrumbs si rimanda alla sezione `breadcrumbs` del sito [Reactstrap (v8)](https://deploy-preview-2356--reactstrap.netlify.app/components/breadcrumbs/).

--- a/stories/Breadcrumb/Breadcrumb.stories.mdx
+++ b/stories/Breadcrumb/Breadcrumb.stories.mdx
@@ -60,4 +60,4 @@ Per la versione su sfondo scuro delle breadcrumbs è sufficiente aggiungere l'at
 
 <ArgsTable of={Breadcrumb} />
 
-Per ulteriori informazioni sui breadcrumbs si rimanda alla sezione `breadcrumbs` del sito [Reactstrap](https://reactstrap.github.io/components/breadcrumbs/).
+Per ulteriori informazioni sui breadcrumbs si rimanda alla sezione `breadcrumbs` del sito [Reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/breadcrumbs/).

--- a/stories/Button/Button.stories.mdx
+++ b/stories/Button/Button.stories.mdx
@@ -128,7 +128,7 @@ Utilizzando invece l'attributo `block` si ottengono invece bottoni che prendono 
 
 È possibile provare a personalizzare live il componente `Button` presso [l'esempio interattivo](?path=/story/componenti-button--esempi-interattivi).
 
-Per ulteriori informazioni sui bottoni si rimanda alla sezione `buttons` del sito [Reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/buttons/), quindi di [Bootstrap](https://getbootstrap.com/docs/4.5/components/buttons/).
+Per ulteriori informazioni sui bottoni si rimanda alla sezione `buttons` del sito [Reactstrap (v8)](https://deploy-preview-2356--reactstrap.netlify.app/components/buttons/), quindi di [Bootstrap](https://getbootstrap.com/docs/4.5/components/buttons/).
 
 ## Argomenti componente
 

--- a/stories/Button/Button.stories.mdx
+++ b/stories/Button/Button.stories.mdx
@@ -128,7 +128,7 @@ Utilizzando invece l'attributo `block` si ottengono invece bottoni che prendono 
 
 È possibile provare a personalizzare live il componente `Button` presso [l'esempio interattivo](?path=/story/componenti-button--esempi-interattivi).
 
-Per ulteriori informazioni sui bottoni si rimanda alla sezione `buttons` del sito [Reactstrap](https://reactstrap.github.io/components/buttons/), quindi di [Bootstrap](https://getbootstrap.com/docs/4.5/components/buttons/).
+Per ulteriori informazioni sui bottoni si rimanda alla sezione `buttons` del sito [Reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/buttons/), quindi di [Bootstrap](https://getbootstrap.com/docs/4.5/components/buttons/).
 
 ## Argomenti componente
 

--- a/stories/Dropdown/Dropdown.stories.mdx
+++ b/stories/Dropdown/Dropdown.stories.mdx
@@ -135,4 +135,4 @@ Aggiungendo la classe `.dark` al componente `DropdownMenu` si ottiene una versio
 
 ### Informazioni aggiuntive
 
-Per consultare altri esempi, vedere l’utilizzo di una dropdown con interi form al suo interno, capire meglio come utilizzare attributi di Bootstrap 4.5.0 , si rimanda alla documentazione sul sito di [reactstrap](https://reactstrap.github.io/components/dropdowns/) e [Bootstrap](https://getbootstrap.com/docs/4.5/components/dropdowns/).
+Per consultare altri esempi, vedere l’utilizzo di una dropdown con interi form al suo interno, capire meglio come utilizzare attributi di Bootstrap 4.5.0 , si rimanda alla documentazione sul sito di [reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/dropdowns/) e [Bootstrap](https://getbootstrap.com/docs/4.5/components/dropdowns/).

--- a/stories/Dropdown/Dropdown.stories.mdx
+++ b/stories/Dropdown/Dropdown.stories.mdx
@@ -135,4 +135,4 @@ Aggiungendo la classe `.dark` al componente `DropdownMenu` si ottiene una versio
 
 ### Informazioni aggiuntive
 
-Per consultare altri esempi, vedere l’utilizzo di una dropdown con interi form al suo interno, capire meglio come utilizzare attributi di Bootstrap 4.5.0 , si rimanda alla documentazione sul sito di [reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/dropdowns/) e [Bootstrap](https://getbootstrap.com/docs/4.5/components/dropdowns/).
+Per consultare altri esempi, vedere l’utilizzo di una dropdown con interi form al suo interno, capire meglio come utilizzare attributi di Bootstrap 4.5.0 , si rimanda alla documentazione sul sito di [reactstrap (v8)](https://deploy-preview-2356--reactstrap.netlify.app/components/dropdowns/) e [Bootstrap](https://getbootstrap.com/docs/4.5/components/dropdowns/).

--- a/stories/Layouts.stories.mdx
+++ b/stories/Layouts.stories.mdx
@@ -153,5 +153,5 @@ Non vuoi che le tue colonne si raccolgano semplicemente su alcune righe della di
   <Story id='componenti-layout-component--mischiare-e-abbinare' />
 </Canvas>
 
-Per maggiori informazioni sui componenti `Container`, `Row` e `Column` fare riferimento [alla documentazione Reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/layout/).
+Per maggiori informazioni sui componenti `Container`, `Row` e `Column` fare riferimento [alla documentazione Reactstrap (v8)](https://deploy-preview-2356--reactstrap.netlify.app/components/layout/).
 Per maggiori informazioni su griglie e configurazioni aggiuntive fare riferimento [alla documentazione di Bootstrap Italia](https://italia.github.io/bootstrap-italia/docs/organizzare-gli-spazi/griglie/).

--- a/stories/Layouts.stories.mdx
+++ b/stories/Layouts.stories.mdx
@@ -153,5 +153,5 @@ Non vuoi che le tue colonne si raccolgano semplicemente su alcune righe della di
   <Story id='componenti-layout-component--mischiare-e-abbinare' />
 </Canvas>
 
-Per maggiori informazioni sui componenti `Container`, `Row` e `Column` fare riferimento [alla documentazione Reactstrap](https://reactstrap.github.io/components/layout/).
+Per maggiori informazioni sui componenti `Container`, `Row` e `Column` fare riferimento [alla documentazione Reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/components/layout/).
 Per maggiori informazioni su griglie e configurazioni aggiuntive fare riferimento [alla documentazione di Bootstrap Italia](https://italia.github.io/bootstrap-italia/docs/organizzare-gli-spazi/griglie/).

--- a/stories/Popover/Popover.stories.mdx
+++ b/stories/Popover/Popover.stories.mdx
@@ -86,4 +86,4 @@ Come soluzione, ti consigliamo di attivare il `Popover` da un elemento `<div/>` 
 
 ## Argomenti componente
 
-Fare riferimento alla documentazione reactstrap per maggiori dettagli sui componenti `Popover` e `UncontrolledPopover`: https://reactstrap.github.io/components/popovers/
+Fare riferimento alla documentazione reactstrap per maggiori dettagli sui componenti `Popover` e `UncontrolledPopover`: https://deploy-preview-2356--reactstrap.netlify.app/components/popovers/

--- a/stories/Popover/Popover.stories.mdx
+++ b/stories/Popover/Popover.stories.mdx
@@ -86,4 +86,4 @@ Come soluzione, ti consigliamo di attivare il `Popover` da un elemento `<div/>` 
 
 ## Argomenti componente
 
-Fare riferimento alla documentazione reactstrap per maggiori dettagli sui componenti `Popover` e `UncontrolledPopover`: https://deploy-preview-2356--reactstrap.netlify.app/components/popovers/
+Fare riferimento alla documentazione reactstrap (v8) per maggiori dettagli sui componenti `Popover` e `UncontrolledPopover`: https://deploy-preview-2356--reactstrap.netlify.app/components/popovers/

--- a/stories/Tooltip/Tooltip.stories.mdx
+++ b/stories/Tooltip/Tooltip.stories.mdx
@@ -68,4 +68,4 @@ Passa il mouse sopra i bottoni sottostanti per vedere le quattro direzioni dei t
 
 ## Argomenti componente
 
-Fare riferimento alla documentazione reactstrap per maggiori dettagli sui componenti `Tooltip` e `UncontrolledTooltip`: https://reactstrap.github.io/components/tooltips/
+Fare riferimento alla documentazione reactstrap per maggiori dettagli sui componenti `Tooltip` e `UncontrolledTooltip`: https://deploy-preview-2356--reactstrap.netlify.app/components/tooltips/

--- a/stories/Tooltip/Tooltip.stories.mdx
+++ b/stories/Tooltip/Tooltip.stories.mdx
@@ -68,4 +68,4 @@ Passa il mouse sopra i bottoni sottostanti per vedere le quattro direzioni dei t
 
 ## Argomenti componente
 
-Fare riferimento alla documentazione reactstrap per maggiori dettagli sui componenti `Tooltip` e `UncontrolledTooltip`: https://deploy-preview-2356--reactstrap.netlify.app/components/tooltips/
+Fare riferimento alla documentazione reactstrap (v8) per maggiori dettagli sui componenti `Tooltip` e `UncontrolledTooltip`: https://deploy-preview-2356--reactstrap.netlify.app/components/tooltips/

--- a/stories/faq.stories.mdx
+++ b/stories/faq.stories.mdx
@@ -14,7 +14,7 @@ Questo kit aspira a coprire interamente i componenti disponibili sul sito Bootst
 
 ### Non trovo la documentazione completa del componente X nel kit, anche se ne esiste una storia/appare in una pagina della documentazione. Dove posso trovarlo?
 
-Se si tratta di un componente Bootstrap, probabilmente è possibile trovare maggiore documentazione sul sito [reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/), cioè della libreria utilizzata da questo kit.
+Se si tratta di un componente Bootstrap, probabilmente è possibile trovare maggiore documentazione sul sito [reactstrap (v8)](https://deploy-preview-2356--reactstrap.netlify.app/), cioè della libreria utilizzata da questo kit.
 Se si tratta di un componente Bootstrap Italia con documentazione mancante/parziale ti invitiamo ad aprire un ticket [sul repository Github](https://github.com/italia/design-react-kit/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
 
 ### Il componente X ha uno stile diverso rispetto a quello in Bootstrap Italia. È un bug?

--- a/stories/faq.stories.mdx
+++ b/stories/faq.stories.mdx
@@ -14,7 +14,7 @@ Questo kit aspira a coprire interamente i componenti disponibili sul sito Bootst
 
 ### Non trovo la documentazione completa del componente X nel kit, anche se ne esiste una storia/appare in una pagina della documentazione. Dove posso trovarlo?
 
-Se si tratta di un componente Bootstrap, probabilmente è possibile trovare maggiore documentazione sul sito [reactstrap](https://reactstrap.github.io/), cioè della libreria utilizzata da questo kit.
+Se si tratta di un componente Bootstrap, probabilmente è possibile trovare maggiore documentazione sul sito [reactstrap](https://deploy-preview-2356--reactstrap.netlify.app/), cioè della libreria utilizzata da questo kit.
 Se si tratta di un componente Bootstrap Italia con documentazione mancante/parziale ti invitiamo ad aprire un ticket [sul repository Github](https://github.com/italia/design-react-kit/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
 
 ### Il componente X ha uno stile diverso rispetto a quello in Bootstrap Italia. È un bug?


### PR DESCRIPTION
Fixes #783 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).

#### Short description of what this resolves:
Replaced links to main reactstrap docs with the ones which point to the previous version of reactstrap
