### PR TITLE
Publish on github pages only on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,10 +189,7 @@ workflows:
       - deploy-github-pages:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
+          filters: *tag_filters
 
       - npm-publish:
           requires:

--- a/README.EN.md
+++ b/README.EN.md
@@ -12,7 +12,7 @@
 
 Components are showcased with [Storybook](https://storybook.js.org/).
 
-Public version of Storybook (built from `master` branch) is available here: https://italia.github.io/design-react-kit.
+Public version of Storybook is available [here](https://italia.github.io/design-react-kit) for the latest stable release, while [here](https://design-react-kit.vercel.app/) for the current development version built from `master` branch.
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Per navigare la libreria e visualizzare i componenti, è stato utilizzato [Storybook](https://storybook.js.org/).
 
-La versione pubblica dello Storybook (relativa al branch `master`) è disponibile [qui](https://italia.github.io/design-react-kit).
+La versione pubblica dello Storybook è disponibile [qui](https://italia.github.io/design-react-kit) per l'ultima release stabile pubblicata, mentre [qui](https://design-react-kit.vercel.app/) per la versione  di sviluppo relativa al branch `master`.
 
 ## Indice
 


### PR DESCRIPTION
Fixes #772

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
This PR sync the current `deploy-github-pages` task with the `npm publish` in order to always sync the published static release with the documentation. As for the `master` branch it will follow the vercel URL with the development deployment.
