### PR TITLE
[Doc] Move Grid and Responsive image args table into ImageList page

### DIFF
--- a/stories/ImagesList/ImagesList.stories.mdx
+++ b/stories/ImagesList/ImagesList.stories.mdx
@@ -1,6 +1,14 @@
-import { Meta, Canvas, Story } from '@storybook/addon-docs';
+import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
+import {
+  GridItem,
+  GridItemText,
+  GridItemTextWrapper,
+  GridList,
+  GridRow,
+  ResponsiveImage
+} from '../../src';
 
-<Meta title='Documentazione/Organizzare i contenuti/Liste di Immagini' />
+<Meta title='Documentazione/Organizzare i contenuti/Liste di Immagini' of={GridList} />
 
 # Liste di Immagini
 
@@ -71,3 +79,29 @@ Di seguito l’esempio
 <Canvas>
   <Story id='componenti-imagelist--masonry' />
 </Canvas>
+
+## Argomenti componente
+
+### GridList
+
+<ArgsTable of={GridList} />
+
+### GridRow
+
+<ArgsTable of={GridRow} />
+
+### GridItem
+
+<ArgsTable of={GridItem} />
+
+### GridItemText
+
+<ArgsTable of={GridItemText} />
+
+### GridItemTextWrapper
+
+<ArgsTable of={GridItemTextWrapper} />
+
+### ResponsiveImage
+
+<ArgsTable of={ResponsiveImage} />

--- a/stories/Tables/Tables.stories.mdx
+++ b/stories/Tables/Tables.stories.mdx
@@ -3,15 +3,10 @@ import {
   Callout,
   CalloutText,
   CalloutTitle,
-  GridItem,
-  GridItemText,
-  GridItemTextWrapper,
-  GridList,
-  GridRow,
-  ResponsiveImage
+  Table
 } from '../../src';
 
-<Meta title='Documentazione/Organizzare i contenuti/Tabelle' />
+<Meta title='Documentazione/Organizzare i contenuti/Tabelle' of={Table}/>
 
 # Tabelle
 
@@ -154,29 +149,3 @@ Combina gli attributi `responsive` e `size` come necessario per creare tabelle r
 <Canvas>
   <Story id='componenti-tables--table-breakpoint' />
 </Canvas>
-
-## Argomenti componente
-
-### GridList
-
-<ArgsTable of={GridList} />
-
-### GridRow
-
-<ArgsTable of={GridRow} />
-
-### GridItem
-
-<ArgsTable of={GridItem} />
-
-### GridItemText
-
-<ArgsTable of={GridItemText} />
-
-### GridItemTextWrapper
-
-<ArgsTable of={GridItemTextWrapper} />
-
-### ResponsiveImage
-
-<ArgsTable of={ResponsiveImage} />


### PR DESCRIPTION

Fixes #807 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [x] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
Move table to the right page as in title.