### PR TITLE
Fix publish bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,14 +189,6 @@ workflows:
               ignore:
                 - gh-pages
 
-      - npm-publish-test:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - gh-pages
-
       - deploy-github-pages:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,6 @@ jobs:
 
       # Download and cache dependencies
       - restore_cache: *restore_cache
-      - run: *npm_install
 
       - attach_workspace:
           # Must be absolute path or relative path from working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,10 @@ jobs:
     steps:
       - checkout
 
+      # Download and cache dependencies
+      - restore_cache: *restore_cache
+      - run: *npm_install
+
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,24 +139,6 @@ jobs:
             yarn storybook:build
             yarn storybook:deploy
 
-  npm-publish-test:
-    <<: *defaults
-
-    steps:
-      - checkout
-
-      # Download and cache dependencies
-      - restore_cache: *restore_cache
-
-      - attach_workspace:
-          # Must be absolute path or relative path from working_directory
-          at: .
-
-      - run:
-          name: npm pack
-          command: |
-            npm pack
-
 
   npm-publish:
     <<: *defaults
@@ -170,9 +152,11 @@ jobs:
 
       - run:
           name: npm publish
+          # Mind that --ignore-scripts for publish is supported for npm <= 7 and >= 7.20
+          # see https://github.com/npm/cli/issues/2755
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            npm publish
+            npm publish --ignore-scripts
 
 # Workflows enable multiple jobs in parallel
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,22 @@ jobs:
             yarn storybook:build
             yarn storybook:deploy
 
+  npm-publish-test:
+    <<: *defaults
+
+    steps:
+      - checkout
+
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: .
+
+      - run:
+          name: npm pack
+          command: |
+            npm pack
+
+
   npm-publish:
     <<: *defaults
 
@@ -179,6 +195,14 @@ workflows:
                 - gh-pages
 
       - check-gatsby-ssr:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - gh-pages
+
+      - npm-publish-test:
           requires:
             - build
           filters:


### PR DESCRIPTION
Fixes #814 

The new codebase runs a local `npm build` + some `husky` stuff to setup the environment locally when developing with the `prepare` script.
Because in the previous setup only the `dist` folder was available as `npm publish` was sending that over to `npm`, the current `prepare` task requires the full repo to be available.

`npm publish` uses the same `prepare` script by default, but it is not used in the CircleCI job as the build process was a requisite anyway: `--ignore-scripts` makes `publish` skip the `prepare` phase and just go as it used to.