### PR TITLE
Fixed rhombus visual bug on megamenu classic

### DIFF
--- a/src/Megamenu/MegamenuItem.tsx
+++ b/src/Megamenu/MegamenuItem.tsx
@@ -9,6 +9,10 @@ export interface MegamenuItemProps extends HTMLAttributes<HTMLUListElement> {
   className?: string;
 }
 
+const styleDropdownToggle = {
+  clipPath: 'polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)'
+};
+
 export const MegamenuItem: FC<MegamenuItemProps> = ({
   itemName,
   className,
@@ -18,7 +22,7 @@ export const MegamenuItem: FC<MegamenuItemProps> = ({
   const classes = classNames(className, 'megamenu');
   return (
     <UncontrolledDropdown nav tag='li' className={classes} {...attributes}>
-      <DropdownToggle caret nav>
+      <DropdownToggle caret nav style={styleDropdownToggle}>
         {itemName}
       </DropdownToggle>
       <DropdownMenu positionFixed>{children}</DropdownMenu>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #882

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
<!-- Please add a short description of what this PR resolves to be clear for the community. -->
In Megamenu Classico when you click the dropdown with a background different than white. You can see the full rhombus instead of only the half on the nav.

With this fix you can see only the half on the nav.

#### Changes proposed in this Pull Request:
<!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
- fix: Issue #882 