### PR TITLE
Fixed Megamenu Margin Visual Bug

### DIFF
--- a/src/Megamenu/MegamenuItem.tsx
+++ b/src/Megamenu/MegamenuItem.tsx
@@ -21,7 +21,14 @@ export const MegamenuItem: FC<MegamenuItemProps> = ({
       <DropdownToggle caret nav>
         {itemName}
       </DropdownToggle>
-      <DropdownMenu positionFixed>{children}</DropdownMenu>
+      <DropdownMenu
+        positionFixed
+        style={{
+          animation: ''
+        }}
+      >
+        {children}
+      </DropdownMenu>
     </UncontrolledDropdown>
   );
 };


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #882 

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
<!-- Please add a short description of what this PR resolves to be clear for the community. -->
It resolves the bug in the Megamenu Classic where there was some space between the nav and the dropdown.
This was a problem in the keyframe animation dropdown of Reactstrap that add a margin.
I resolved the bug removing the animation. 

#### Changes proposed in this Pull Request:
<!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
- fix: Issue #882  removing animation dropdown
