### PR TITLE
Fix accordion's arrow orientation

### DIFF
--- a/src/Accordion/AccordionHeader.tsx
+++ b/src/Accordion/AccordionHeader.tsx
@@ -26,7 +26,7 @@ export const AccordionHeader: FC<AccordionHeaderProps> = ({
 }) => {
   const Tag = tag;
   const toggleClasses = classNames(className, 'accordion-button', {
-    collapsed: active
+    collapsed: !active
   });
   return (
     <div className='accordion-header' data-testid={testId}>

--- a/test/Accordion.test.tsx
+++ b/test/Accordion.test.tsx
@@ -31,6 +31,20 @@ describe('Accordion component', () => {
     expect(container.getElementsByClassName('accordion-button').length).toBe(1);
   });
 
+  it('should have the class collapsed when collapsed', () => {
+    const { container } = render(
+      <Accordion>
+        <AccordionItem>
+          <AccordionHeader>Content</AccordionHeader>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    expect(
+      container.getElementsByClassName('accordion-button collapsed').length
+    ).toBe(1);
+  });
+
   it('should have a testId for resilient UI changes', () => {
     const collapse = render(
       <Accordion testId={'test-id-accordion'}>Content</Accordion>


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
<!-- Please add a short description of what this PR resolves to be clear for the community. -->
This PR changes the arrow orientation in the Accordion component, so that it points down when collapsed and up when not.  
The accordion is expanded when it has the prop `active` set to true, so the class `collapsed` should be set when `active === false`, but it was the opposite.