### PR TITLE
fix: full responsive right action button in slim header breaking into two lines

### DIFF
--- a/stories/Header/SlimHeader/basic-full-responsive.tsx
+++ b/stories/Header/SlimHeader/basic-full-responsive.tsx
@@ -44,7 +44,7 @@ const SlimHeader = ({ theme }: ThemeType) => {
               </Row>
             </DropdownMenu>
           </UncontrolledDropdown>
-          <Button color='primary' block className='btn-icon' href='#'>
+          <Button color='primary' className='btn-icon btn-full' href='#'>
             <span className='rounded-icon'>
               <Icon color='primary' icon='it-user' />
             </span>


### PR DESCRIPTION
#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).

#### Short description of what this resolves:
<!-- Please add a short description of what this PR resolves to be clear for the community. -->
This PR resolves an issue with the Headers stories which makes the button break into two lines. The prop `block`, which is currently passed to the `Button` component, adds a `display: block !important` to the element, overriding the `display: flex` set by the class `.btn-icon`.

#### Changes proposed in this Pull Request:
<!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
- Removed the `block` prop
- passed the class `.btn-full` to remove the rounded corners, so that it looks the same as BI example
