### PR TITLE
fix: wrong instructions in "Right action con bottone full responsive" docs

### DIFF
--- a/stories/Header/Headers.stories.mdx
+++ b/stories/Header/Headers.stories.mdx
@@ -33,9 +33,7 @@ Lo _Slim header_ header mostra un’intestazione, solitamente con riferimento al
 
 #### Right action con bottone full responsive
 
-Per trasformare il bottone di action situato nella `HeaderRightZone` e renderlo full-responsive è sufficiente applicare la prop `size="full"` al link/bottone.
-
-Il modificatore `"full"` è disponibile anche con il tema chiaro attivato da .theme-light.
+Per trasformare il bottone di action situato nella `HeaderRightZone` e renderlo full-responsive è sufficiente aggiungere la classe `btn-full` alla prop `classNames` del bottone.
 
 <Canvas>
   <Story id='componenti-header--slim-header-with-full-button' />


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [x] My branch is up-to-date with the Upstream `master` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [ ] <s>I have added tests that prove my fix is effective or that my feature works (if applicable).</s>
- [ ] <s>I have added necessary documentation (if appropriate).</s>

#### Short description of what this resolves:
The docs suggest to apply the prop `size="full"` to the button to make it fully responsive, but `size` doesn't accept such a value. The right way is to add the class `btn-full` to the button.

#### Changes proposed in this Pull Request:
From
> Per trasformare il bottone di action situato nella `HeaderRightZone` e renderlo full-responsive è sufficiente applicare la prop `size="full"` al link/bottone.
Il modificatore `"full"` è disponibile anche con il tema chiaro attivato da .theme-light.

to
> Per trasformare il bottone di action situato nella `HeaderRightZone` e renderlo full-responsive è sufficiente aggiungere la classe `btn-full` alla prop `classNames` del bottone.