### PR TITLE
fix: set default value for `text` prop in `Input`

### DIFF
--- a/src/Input/Input.tsx
+++ b/src/Input/Input.tsx
@@ -106,7 +106,7 @@ export const Input = ({
   id,
   className,
   cssModule,
-  type,
+  type = 'text',
   state,
   tag,
   addon,


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### PR Checklist
<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->
- [ ] My branch is up-to-date with the Upstream `master` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:
<!-- Please add a short description of what this PR resolves to be clear for the community. -->
According to the docs the default Input type should be `text`.

#### Changes proposed in this Pull Request:
<!-- You can use a few bullet points to describe some implementation changes proposed. For Example - feat: adding navbar component -->
-
