### PR TITLE
fix: dropdown import type warning

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -244,7 +244,6 @@ export type { ToggleProps } from './Toggle/Toggle';
 export type { ToolbarProps } from './Toolbar/Toolbar';
 export type { ToolbarItemBadge, ToolbarItemProps } from './Toolbar/ToolbarItem';
 
-export type { ChangesType, RegisterOptions, useNavScrollArgs, useNavScrollResult } from 'react-use-navscroll';
 export type {
   BreadcrumbItemProps,
   ButtonDropdownProps,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,31 +1,19 @@
 export {
-  Container,
-  Row,
-  Col,
-  Navbar,
-  NavbarBrand,
-  NavbarToggler,
-  NavItem,
-  NavLink,
   BreadcrumbItem,
   ButtonGroup,
   ButtonToolbar,
-  Fade,
-  CardLink,
-  CardGroup,
-  CardDeck,
   CardColumns,
+  CardDeck,
   CardFooter,
+  CardGroup,
   CardHeader,
   CardImg,
   CardImgOverlay,
+  CardLink,
   CardSubtitle,
-  Popover,
-  PopoverBody,
-  PopoverHeader,
-  Tooltip,
-  Table,
-  ListGroup,
+  Col,
+  Container,
+  Fade,
   Form,
   FormFeedback,
   FormGroup,
@@ -33,14 +21,26 @@ export {
   InputGroup,
   InputGroupText,
   Label,
+  ListGroup,
+  ListGroupItem,
+  ListGroupItemHeading,
+  ListGroupItemText,
   Media,
+  NavItem,
+  NavLink,
+  Navbar,
+  NavbarBrand,
+  NavbarToggler,
   PaginationItem as PagerItem,
   PaginationLink as PagerLink,
+  Popover,
+  PopoverBody,
+  PopoverHeader,
+  Row,
   TabContent,
   TabPane,
-  ListGroupItem,
-  ListGroupItemText,
-  ListGroupItemHeading,
+  Table,
+  Tooltip,
   UncontrolledAlert,
   UncontrolledCollapse,
   UncontrolledTooltip,
@@ -49,44 +49,51 @@ export {
 
 export { useNavScroll } from 'react-use-navscroll';
 
-export { Alert } from './Alert/Alert';
 export { Accordion } from './Accordion/Accordion';
-export { AccordionItem } from './Accordion/AccordionItem';
-export { AccordionHeader } from './Accordion/AccordionHeader';
 export { AccordionBody } from './Accordion/AccordionBody';
+export { AccordionHeader } from './Accordion/AccordionHeader';
+export { AccordionItem } from './Accordion/AccordionItem';
+export { Alert } from './Alert/Alert';
 export { AvatarContainer } from './Avatar/AvatarContainer';
-export { AvatarGroupContainer } from './Avatar/AvatarGroupContainer';
 export { AvatarExtraText } from './Avatar/AvatarExtraText';
+export { AvatarGroupContainer } from './Avatar/AvatarGroupContainer';
 export { AvatarIcon } from './Avatar/AvatarIcon';
 export { AvatarPresence } from './Avatar/AvatarPresence';
 export { AvatarStatus } from './Avatar/AvatarStatus';
 export { AvatarWrapper } from './Avatar/AvatarWrapper';
 export { BackToTop } from './BackToTop/BackToTop';
 export { Badge } from './Badge/Badge';
+export { BottomNav } from './BottomNav/BottomNav';
+export { BottomNavItem } from './BottomNav/BottomNavItem';
 export { Breadcrumb } from './Breadcrumb/Breadcrumb';
 export { Button } from './Button/Button';
-export { Forward } from './Forward/Forward';
 export { Callout } from './Callout/Callout';
+export { CalloutMoreFooter } from './Callout/CalloutMoreFooter';
 export { CalloutText } from './Callout/CalloutText';
 export { CalloutTitle } from './Callout/CalloutTitle';
-export { CalloutMoreFooter } from './Callout/CalloutMoreFooter';
 export { Card } from './Card/Card';
 export { CardBody } from './Card/CardBody';
-export { CardTitle } from './Card/CardTitle';
-export { CardText } from './Card/CardText';
 export { CardCategory } from './Card/CardCategory';
-export { CardTag } from './Card/CardTag';
-export { CardTagsHeader } from './Card/CardTagsHeader';
-export { CardSignature } from './Card/CardSignature';
 export { CardFooterCTA } from './Card/CardFooterCTA';
 export { CardReadMore } from './Card/CardReadMore';
+export { CardSignature } from './Card/CardSignature';
+export { CardTag } from './Card/CardTag';
+export { CardTagsHeader } from './Card/CardTagsHeader';
+export { CardText } from './Card/CardText';
+export { CardTitle } from './Card/CardTitle';
+export { Chip } from './Chips/Chip';
+export { ChipLabel } from './Chips/ChipLabel';
 export { Collapse } from './Collapse/Collapse';
+export { Dimmer } from './Dimmer/Dimmer';
+export { DimmerButtons } from './Dimmer/DimmerButtons';
+export { Dropdown } from './Dropdown/Dropdown';
 export { DropdownMenu } from './Dropdown/DropdownMenu';
 export { DropdownToggle } from './Dropdown/DropdownToggle';
-export { Dropdown } from './Dropdown/Dropdown';
+export { FontLoader, useFontLoader } from './FontLoader/FontLoader';
+export { Forward } from './Forward/Forward';
+export { GoBack } from './GoBack/GoBack';
 export { GridItem, GridItemText, GridItemTextWrapper, GridList, GridRow } from './Grid/index';
 export { Header } from './Header/Header';
-export { Headers } from './Header/Headers';
 export { HeaderBrand } from './Header/HeaderBrand';
 export { HeaderContent } from './Header/HeaderContent';
 export { HeaderLinkZone } from './Header/HeaderLinkZone';
@@ -94,87 +101,87 @@ export { HeaderRightZone } from './Header/HeaderRightZone';
 export { HeaderSearch } from './Header/HeaderSearch';
 export { HeaderSocialsZone } from './Header/HeaderSocialsZone';
 export { HeaderToggler } from './Header/HeaderToggler';
+export { Headers } from './Header/Headers';
 export { Hero, HeroBackground, HeroBody, HeroButton, HeroCategory, HeroTitle } from './Hero/index';
-export { Icon, iconsList as icons, preloadIcons, clearIconCache } from './Icon/Icon';
+export { Icon, clearIconCache, iconsList as icons, preloadIcons } from './Icon/Icon';
 export { Input } from './Input/Input';
 export { InputContainer } from './Input/InputContainer';
 export { TextArea } from './Input/TextArea';
-export { GoBack } from './GoBack/GoBack';
 export { LinkList } from './LinkList/LinkList';
 export { LinkListItem } from './LinkList/LinkListItem';
-export { MegamenuItem } from './Megamenu/MegamenuItem';
 export { MegamenuFooter } from './Megamenu/MegamenuFooter';
 export { MegamenuHighlightColumn } from './Megamenu/MegamenuHighlightColumn';
+export { MegamenuItem } from './Megamenu/MegamenuItem';
 export { Modal } from './Modal/Modal';
-export { ModalHeader } from './Modal/ModalHeader';
 export { ModalBody } from './Modal/ModalBody';
 export { ModalFooter } from './Modal/ModalFooter';
+export { ModalHeader } from './Modal/ModalHeader';
 export { Nav } from './Nav/Nav';
+export { NotificationManager, createNotification, notify } from './Notification';
 export { Pager } from './Pager/Pager';
+export { Progress } from './Progress/Progress';
 export { Rating } from './Rating/Rating';
 export { ResponsiveImage } from './ResponsiveImage/ResponsiveImage';
+export { Section } from './Section/Section';
+export { Select } from './Select/Select';
+export { Sidebar } from './Sidebar/Sidebar';
 export { Skiplink } from './Skiplink/Skiplink';
 export { SkiplinkItem } from './Skiplink/SkiplinkItem';
-export { Toggle } from './Toggle/Toggle';
-export { Sidebar } from './Sidebar/Sidebar';
-export { Progress } from './Progress/Progress';
 export { Spinner } from './Spinner/Spinner';
-export { BottomNav } from './BottomNav/BottomNav';
-export { BottomNavItem } from './BottomNav/BottomNavItem';
-export { ThumbNav } from './ThumbNav/ThumbNav';
-export { ThumbNavItem } from './ThumbNav/ThumbNavItem';
-export { Chip } from './Chips/Chip';
-export { ChipLabel } from './Chips/ChipLabel';
-export { FontLoader, useFontLoader } from './FontLoader/FontLoader';
-export { Dimmer } from './Dimmer/Dimmer';
-export { DimmerButtons } from './Dimmer/DimmerButtons';
-export { Timeline } from './Timeline/TimelineWrapper';
-export { TimelinePin } from './Timeline/TimelinePin';
-export { Select } from './Select/Select';
-export { StepperHeader } from './Stepper/StepperHeader';
 export { StepperContainer } from './Stepper/StepperContainer';
+export { StepperContent } from './Stepper/StepperContent';
+export { StepperDots } from './Stepper/StepperDots';
+export { StepperHeader } from './Stepper/StepperHeader';
 export { StepperHeaderElement } from './Stepper/StepperHeaderElement';
 export { StepperNav } from './Stepper/StepperNav';
-export { StepperDots } from './Stepper/StepperDots';
-export { StepperContent } from './Stepper/StepperContent';
-export { Section } from './Section/Section';
-export { NotificationManager, notify, createNotification } from './Notification';
+export { ThumbNav } from './ThumbNav/ThumbNav';
+export { ThumbNavItem } from './ThumbNav/ThumbNavItem';
+export { TimelinePin } from './Timeline/TimelinePin';
+export { Timeline } from './Timeline/TimelineWrapper';
+export { Toggle } from './Toggle/Toggle';
 export { Toolbar } from './Toolbar/Toolbar';
-export { ToolbarItem } from './Toolbar/ToolbarItem';
 export { ToolbarDividerItem } from './Toolbar/ToolbarDividerItem';
+export { ToolbarItem } from './Toolbar/ToolbarItem';
 
 // Types
-export type { AlertProps } from './Alert/Alert';
 export type { AccordionProps } from './Accordion/Accordion';
-export type { AccordionHeaderProps } from './Accordion/AccordionHeader';
 export type { AccordionBodyProps } from './Accordion/AccordionBody';
+export type { AccordionHeaderProps } from './Accordion/AccordionHeader';
+export type { AlertProps } from './Alert/Alert';
 export type { AvatarContainerProps } from './Avatar/AvatarContainer';
-export type { AvatarGroupContainerProps } from './Avatar/AvatarGroupContainer';
 export type { AvatarExtraTextProps } from './Avatar/AvatarExtraText';
+export type { AvatarGroupContainerProps } from './Avatar/AvatarGroupContainer';
 export type { AvatarIconProps } from './Avatar/AvatarIcon';
 export type { AvatarPresenceProps } from './Avatar/AvatarPresence';
 export type { AvatarStatusProps } from './Avatar/AvatarStatus';
 export type { AvatarWrapperProps } from './Avatar/AvatarWrapper';
 export type { BadgeProps } from './Badge/Badge';
+export type { BottomNavProps } from './BottomNav/BottomNav';
+export type { BottomNavItemProps } from './BottomNav/BottomNavItem';
 export type { BreadcrumbProps } from './Breadcrumb/Breadcrumb';
 export type { ButtonProps } from './Button/Button';
-export type { ForwardProps } from './Forward/Forward';
 export type { CalloutProps } from './Callout/Callout';
 export type { CalloutTextProps } from './Callout/CalloutText';
 export type { CalloutTitleProps } from './Callout/CalloutTitle';
 export type { CardProps } from './Card/Card';
 export type { CardBodyProps } from './Card/CardBody';
-export type { CardTitleProps } from './Card/CardTitle';
-export type { CardTextProps } from './Card/CardText';
 export type { CardCategoryProps } from './Card/CardCategory';
-export type { CardTagProps } from './Card/CardTag';
-export type { CardTagsHeaderProps } from './Card/CardTagsHeader';
-export type { CardSignatureProps } from './Card/CardSignature';
 export type { CardFooterCTAProps } from './Card/CardFooterCTA';
 export type { CardReadMoreProps } from './Card/CardReadMore';
-export { DropdownMenuProps } from './Dropdown/DropdownMenu';
-export { DropdownToggleProps } from './Dropdown/DropdownToggle';
-export { DropdownProps } from './Dropdown/Dropdown';
+export type { CardSignatureProps } from './Card/CardSignature';
+export type { CardTagProps } from './Card/CardTag';
+export type { CardTagsHeaderProps } from './Card/CardTagsHeader';
+export type { CardTextProps } from './Card/CardText';
+export type { CardTitleProps } from './Card/CardTitle';
+export type { ChipProps } from './Chips/Chip';
+export type { ChipLabelProps } from './Chips/ChipLabel';
+export type { DimmerProps } from './Dimmer/Dimmer';
+export type { DimmerButtonsProps } from './Dimmer/DimmerButtons';
+export type { DropdownProps } from './Dropdown/Dropdown';
+export type { DropdownMenuProps } from './Dropdown/DropdownMenu';
+export type { DropdownToggleProps } from './Dropdown/DropdownToggle';
+export type { FontLoaderProps } from './FontLoader/FontLoader';
+export type { ForwardProps } from './Forward/Forward';
 export type {
   GridItemProps,
   GridItemTextProps,
@@ -183,7 +190,6 @@ export type {
   GridRowProps
 } from './Grid/index';
 export type { HeaderProps } from './Header/Header';
-export type { HeadersProps } from './Header/Headers';
 export type { HeaderBrandProps } from './Header/HeaderBrand';
 export type { HeaderContentProps } from './Header/HeaderContent';
 export type { HeaderLinkZoneProps } from './Header/HeaderLinkZone';
@@ -191,106 +197,100 @@ export type { HeaderRightZoneProps } from './Header/HeaderRightZone';
 export type { HeaderSearchProps } from './Header/HeaderSearch';
 export type { HeaderSocialsZoneProps } from './Header/HeaderSocialsZone';
 export type { HeaderTogglerProps } from './Header/HeaderToggler';
+export type { HeadersProps } from './Header/Headers';
 export type {
-  HeroProps,
   HeroBackgroundProps,
   HeroBodyProps,
   HeroButtonProps,
   HeroCategoryProps,
+  HeroProps,
   HeroTitleProps
 } from './Hero/index';
-export type { IconProps, IconName } from './Icon/Icon';
+export type { IconName, IconProps } from './Icon/Icon';
 export type { InputProps } from './Input/Input';
 export type { InputContainerProps } from './Input/InputContainer';
 export type { TextAreaProps } from './Input/TextArea';
 export type { LinkListProps } from './LinkList/LinkList';
 export type { LinkListItemProps } from './LinkList/LinkListItem';
-export type { MegamenuItemProps } from './Megamenu/MegamenuItem';
 export type { MegamenuFooterProps } from './Megamenu/MegamenuFooter';
 export type { MegamenuHCProps } from './Megamenu/MegamenuHighlightColumn';
+export type { MegamenuItemProps } from './Megamenu/MegamenuItem';
 export type { ModalProps } from './Modal/Modal';
-export type { ModalHeaderProps } from './Modal/ModalHeader';
 export type { ModalBodyProps } from './Modal/ModalBody';
 export type { ModalFooterProps } from './Modal/ModalFooter';
+export type { ModalHeaderProps } from './Modal/ModalHeader';
 export type { NavProps } from './Nav/Nav';
+export type { NotificationId, NotificationManagerProps, NotificationOptions, NotificationProps } from './Notification';
 export type { PagerProps } from './Pager/Pager';
+export type { ProgressProps } from './Progress/Progress';
 export type { RatingProps } from './Rating/Rating';
 export type { ResponsiveImageProps } from './ResponsiveImage/ResponsiveImage';
-export type { SkiplinkProps } from './Skiplink/Skiplink';
-export type { SkiplinkItemProps } from './Skiplink/SkiplinkItem';
-export type { ToggleProps } from './Toggle/Toggle';
-export type { SidebarProps } from './Sidebar/Sidebar';
-export type { ProgressProps } from './Progress/Progress';
-export type { SpinnerProps } from './Spinner/Spinner';
-export type { BottomNavProps } from './BottomNav/BottomNav';
-export type { BottomNavItemProps } from './BottomNav/BottomNavItem';
-export type { ThumbNavProps } from './ThumbNav/ThumbNav';
-export type { ThumbNavItemProps } from './ThumbNav/ThumbNavItem';
-export type { ChipProps } from './Chips/Chip';
-export type { ChipLabelProps } from './Chips/ChipLabel';
-export type { FontLoaderProps } from './FontLoader/FontLoader';
-export type { DimmerProps } from './Dimmer/Dimmer';
-export type { DimmerButtonsProps } from './Dimmer/DimmerButtons';
-export type { TimelineProps } from './Timeline/TimelineWrapper';
-export type { TimelinePinProps } from './Timeline/TimelinePin';
-export type { StepperHeaderProps } from './Stepper/StepperHeader';
-export type { StepperContainerProps } from './Stepper/StepperContainer';
-export type { StepperHeaderElementProps } from './Stepper/StepperHeaderElement';
-export type { StepperNavProps } from './Stepper/StepperNav';
-export type { StepperDotsProps } from './Stepper/StepperDots';
-export type { StepperContentProps } from './Stepper/StepperContent';
 export type { SectionProps } from './Section/Section';
 export type { SelectProps } from './Select/Select';
-export type { NotificationId, NotificationProps, NotificationManagerProps, NotificationOptions } from './Notification';
+export type { SidebarProps } from './Sidebar/Sidebar';
+export type { SkiplinkProps } from './Skiplink/Skiplink';
+export type { SkiplinkItemProps } from './Skiplink/SkiplinkItem';
+export type { SpinnerProps } from './Spinner/Spinner';
+export type { StepperContainerProps } from './Stepper/StepperContainer';
+export type { StepperContentProps } from './Stepper/StepperContent';
+export type { StepperDotsProps } from './Stepper/StepperDots';
+export type { StepperHeaderProps } from './Stepper/StepperHeader';
+export type { StepperHeaderElementProps } from './Stepper/StepperHeaderElement';
+export type { StepperNavProps } from './Stepper/StepperNav';
+export type { ThumbNavProps } from './ThumbNav/ThumbNav';
+export type { ThumbNavItemProps } from './ThumbNav/ThumbNavItem';
+export type { TimelinePinProps } from './Timeline/TimelinePin';
+export type { TimelineProps } from './Timeline/TimelineWrapper';
+export type { ToggleProps } from './Toggle/Toggle';
 export type { ToolbarProps } from './Toolbar/Toolbar';
-export type { ToolbarItemProps, ToolbarItemBadge } from './Toolbar/ToolbarItem';
+export type { ToolbarItemBadge, ToolbarItemProps } from './Toolbar/ToolbarItem';
 
+export type { ChangesType, RegisterOptions, useNavScrollArgs, useNavScrollResult } from 'react-use-navscroll';
 export type {
-  ContainerProps,
-  RowProps,
-  ColProps,
-  NavbarProps,
-  NavbarBrandProps,
-  NavbarTogglerProps,
-  NavItemProps,
-  NavLinkProps,
   BreadcrumbItemProps,
   ButtonDropdownProps,
   ButtonGroupProps,
   ButtonToolbarProps,
-  FadeProps,
-  CardLinkProps,
-  CardGroupProps,
-  CardDeckProps,
   CardColumnsProps,
+  CardDeckProps,
   CardFooterProps,
+  CardGroupProps,
   CardHeaderProps,
-  CardImgProps,
   CardImgOverlayProps,
+  CardImgProps,
+  CardLinkProps,
   CardSubtitleProps,
-  PopoverProps,
-  PopoverBodyProps,
-  PopoverHeaderProps,
-  TooltipProps,
-  TableProps,
-  ListGroupProps,
-  FormProps,
+  ColProps,
+  ContainerProps,
+  FadeProps,
   FormFeedbackProps,
   FormGroupProps,
+  FormProps,
   FormTextProps,
   InputGroupProps,
   InputGroupTextProps,
   LabelProps,
-  MediaProps,
-  PaginationItem as PagerItemProps,
-  PaginationLink as PagerLinkProps,
-  TabContentProps,
-  TabPaneProps,
+  ListGroupItemHeadingProps,
   ListGroupItemProps,
   ListGroupItemTextProps,
-  ListGroupItemHeadingProps,
+  ListGroupProps,
+  MediaProps,
+  NavItemProps,
+  NavLinkProps,
+  NavbarBrandProps,
+  NavbarProps,
+  NavbarTogglerProps,
+  PaginationItem as PagerItemProps,
+  PaginationLink as PagerLinkProps,
+  PopoverBodyProps,
+  PopoverHeaderProps,
+  PopoverProps,
+  RowProps,
+  TabContentProps,
+  TabPaneProps,
+  TableProps,
+  TooltipProps,
   UncontrolledAlertProps,
   UncontrolledCollapseProps,
   UncontrolledTooltipProps
 } from 'reactstrap';
-export type { useNavScrollArgs, useNavScrollResult, RegisterOptions, ChangesType } from 'react-use-navscroll';


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Resolve these warnings
```
WARN export 'DropdownProps' (reexported as 'DropdownProps') was not found in './Dropdown/Dropdown' (possible exports: Dropdown)
WARN export 'DropdownMenuProps' (reexported as 'DropdownMenuProps') was not found in './Dropdown/DropdownMenu' (possible exports: DropdownMenu)
WARN export 'DropdownToggleProps' (reexported as 'DropdownToggleProps') was not found in './Dropdown/DropdownToggle' (possible exports: DropdownToggle)
```

The file was reformatted with prettier and eslint but I only added this:
```
export type { DropdownMenuProps } from './Dropdown/DropdownMenu';
export type { DropdownToggleProps } from './Dropdown/DropdownToggle';
export type { DropdownProps } from './Dropdown/Dropdown';
```
