### PR TITLE
fix: accordion types error

### DIFF
--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
-import React, { ElementType, FC } from 'react';
+import React, { ElementType, FC, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-export interface AccordionProps {
+export interface AccordionProps extends HTMLAttributes<HTMLElement> {
   /** Utilizzarlo in caso di utilizzo di componenti personalizzati */
   tag?: ElementType;
   /** Classi aggiuntive da usare per il componente Badge */

--- a/src/Accordion/AccordionHeader.tsx
+++ b/src/Accordion/AccordionHeader.tsx
@@ -1,7 +1,7 @@
-import React, { FC, ReactNode, ElementType } from 'react';
 import classNames from 'classnames';
+import React, { ElementType, FC, HTMLAttributes, ReactNode } from 'react';
 
-export interface AccordionHeaderProps {
+export interface AccordionHeaderProps extends HTMLAttributes<HTMLElement> {
   /** Utilizzarlo in caso di utilizzo di componenti personalizzati */
   tag?: ElementType;
   /** Classi aggiuntive da usare per il componente AccordionHeader */

--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -1,7 +1,7 @@
-import React, { ElementType, FC } from 'react';
 import classNames from 'classnames';
+import React, { ElementType, FC, HTMLAttributes } from 'react';
 
-export interface AccordionItemProps {
+export interface AccordionItemProps extends HTMLAttributes<HTMLElement> {
   /** Utilizzarlo in caso di utilizzo di componenti personalizzati */
   tag?: ElementType;
   /** Classi aggiuntive da usare per il componente */


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1034

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

I extended the accordion element interfaces with react's HTML interface
