### PR TITLE
fix: select must not ignore provided props (fixes #1041)

### DIFF
--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -21,12 +21,13 @@ export interface SelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement
   onChange: (selectedValue: string) => void;
 }
 
-export const Select = ({ id, disabled = false, label, children, onChange }: SelectProps) => {
+export const Select = ({ id, disabled = false, label, children, onChange, ...rest }: SelectProps) => {
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     onChange(e.target.value);
   };
 
   const inputProps = {
+    ...rest,
     disabled: disabled,
     onChange: handleChange
   };


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1041 

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

This PR makes sure that the `Select` component does not ignore the provided props, passing them on correctly to the `<select>` tag.

#### Changes proposed in this Pull Request:

Capturing all remaining props with `{...rest}` and spreading them again into `inputProps` which is in turn spreaded into the `<select>` tag.
