### PR TITLE
fix: refresh callback declaration fix in useNavScroll

### DIFF
--- a/src/NavScroll/useNavScroll.ts
+++ b/src/NavScroll/useNavScroll.ts
@@ -122,12 +122,11 @@ export function useNavScroll(args: useNavScrollArgs = {}): useNavScrollResult {
     forceRecompute
   ]);
 
-  const refresh = useCallback(
+  const refresh = useCallback(() => {
     debounce(() => {
       setCounter(counter + 1);
-    }, REGISTER_DELAY),
-    [counter]
-  );
+    }, REGISTER_DELAY);
+  }, [counter]);
 
   const register = useCallback(
     (id, options = {}) => {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1057 

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [X] My branch is up-to-date with the Upstream `main` branch.
- [X] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

This PR resolves an infinite render loop when using `useNavScroll`.

#### Changes proposed in this Pull Request:

I propose to change the current `refresh` callback declaration which causes an infinite render loop.
Changes have been successfully tested by copying the first example in https://italia.github.io/design-react-kit/?path=/docs/documentazione-menu-di-navigazione-navscroll--documentazione in the `design-react-kit-playground` project: navigation items are correctly updated and no infinite render loop occurs.
