### PR TITLE
Update README.md - Fix typo in Vite create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Per giocare con la libreria è disponibile il [Playground React Kit](https://git
 Per utilizzare Design React come dipendenza in un'app è possibile installarla da [npm](https://www.npmjs.com/~italia). Suggeriamo di usare `create vite` per creare una nuova webapp React, come segue:
 
 ```sh
-yarn create vite my-react-app --template react
+yarn create vite nome-app --template react
 cd nome-app
 yarn add design-react-kit --save
 ```


### PR DESCRIPTION

<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [ ] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Ho corretto il comando `yarn create vite my-react-app --template react`, sostituendo il placeholder "`my-react-app`" con "`nome-app`" per mantenere la coerenza con il passaggio successivo.
Questo rende più chiaro il flusso per gli utenti che seguono il tutorial.


