### PR TITLE
fix: classe form-control mancante in textarea

### DIFF
--- a/src/Input/TextArea.tsx
+++ b/src/Input/TextArea.tsx
@@ -1,8 +1,8 @@
-import React, { Ref, ReactNode, TextareaHTMLAttributes } from 'react';
+import React, { ReactNode, Ref, TextareaHTMLAttributes } from 'react';
 
-import { InputContainer } from './InputContainer';
-import { getClasses, getValidationTextControlClass, useFocus } from './utils';
 import type { CSSModule } from 'reactstrap/types/lib/utils';
+import { InputContainer } from './InputContainer';
+import { getClasses, getFormControlClass, getValidationTextControlClass, useFocus } from './utils';
 
 export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /** Etichetta del campo TextArea. */
@@ -56,6 +56,12 @@ export const TextArea = ({
 
   const extraAttributes: { ['aria-describedby']?: string } = {};
 
+  const formControlClass = getFormControlClass(
+    {
+      normalized
+    },
+    cssModule
+  );
   // associate the input field with the help text
   const infoId = id ? `${id}Description` : undefined;
   if (id) {
@@ -73,6 +79,7 @@ export const TextArea = ({
       label,
       validationText,
       normalized: Boolean(normalized),
+      formControlClass,
       validationTextControlClass,
       isFocused,
       originalWrapperClass

--- a/src/Input/TextArea.tsx
+++ b/src/Input/TextArea.tsx
@@ -56,10 +56,9 @@ export const TextArea = ({
 
   const extraAttributes: { ['aria-describedby']?: string } = {};
 
+  //Chiamo questa funzione per impostare classNames a 'form-control'
   const formControlClass = getFormControlClass(
-    {
-      normalized
-    },
+    {},
     cssModule
   );
   // associate the input field with the help text

--- a/test/Input.test.tsx
+++ b/test/Input.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
 
 import { Button, Icon, Input, preloadIcons } from '../src';
 
@@ -141,4 +141,12 @@ test('should have an left icon and right button', () => {
     const svg = span.querySelector('svg');
     if (svg) expect(svg.nodeName).toBe('svg');
   }
+});
+
+it('should have form-control as class', () => {
+  const { container } = render(
+    <Input />
+  );
+
+  expect(container.firstChild).toHaveClass('form-control');
 });

--- a/test/TextArea.test.tsx
+++ b/test/TextArea.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
 
 import { TextArea } from '../src';
 
@@ -33,4 +33,12 @@ test('should have a testId for resilient UI changes', () => {
   render(<TextArea testId='test-id-text-area' />);
 
   expect(screen.getByTestId('test-id-text-area')).toBeTruthy();
+});
+
+it('should have form-control as class', () => {
+  const { container } = render(
+    <TextArea />
+  );
+
+  expect(container.firstChild).toHaveClass('form-control');
 });

--- a/test/__snapshots__/Storybook.test.tsx.snap
+++ b/test/__snapshots__/Storybook.test.tsx.snap
@@ -20588,7 +20588,7 @@ exports[`Stories Snapshots Documentazione/Form/Input AreaDiTesto 1`] = `
       Esempio di area di testo
     </label>
     <textarea
-      class=""
+      class="form-control"
       rows="3"
     />
     <div
@@ -20611,7 +20611,7 @@ exports[`Stories Snapshots Documentazione/Form/Input AreaDiTestoConSegnaposto 1`
     </label>
     <textarea
       aria-describedby="example-textarea-placeholderDescription"
-      class=""
+      class="form-control"
       id="example-textarea-placeholder"
       placeholder="Testo di esempio"
       rows="3"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #1118 

#### PR Checklist

<!-- To Mark a Checklist box, put "x" inside the square brackets. For Example - [ ] becomes [x] -->

- [x] My branch is up-to-date with the Upstream `main` branch.
- [x] The unit tests pass locally with my changes (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [ ] I have added necessary documentation (if appropriate).

#### Short description of what this resolves:

Corretta applicazione classe al componente
