### PR TITLE
feat: deploy versioned docs to GitHub Pages

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,13 +32,46 @@ jobs:
         with:
           bodyFile: 'RELEASE_BODY.md'
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish on gh-pages
+      - name: Build Storybook
+        run: yarn storybook:build
+      - name: Extract version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+      - name: Deploy docs for this version
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+          destination_dir: ${{ env.VERSION }}
+          keep_files: true
+      - name: Deploy docs as latest
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+          destination_dir: latest
+          keep_files: true
+      - name: Create root redirect to latest
         run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          yarn storybook:build
-          yarn storybook:deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          mkdir -p /tmp/root
+          cat > /tmp/root/index.html << 'REDIRECT'
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0;url=latest/">
+              <link rel="canonical" href="latest/">
+            </head>
+            <body>
+              <p>Redirecting to <a href="latest/">latest documentation</a>...</p>
+            </body>
+          </html>
+          REDIRECT
+      - name: Deploy root redirect
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/root
+          keep_files: true
       - uses: italia/slack-notify-release-action@v0.4.0
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,7 @@ name: Generate new release
 on:
   push:
     tags:
-      - 'v5*'
+      - "v5*"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: git config
         run: |
           git config user.name "${GITHUB_ACTOR}"
@@ -30,48 +30,8 @@ jobs:
         run: yarn --silent extract-changelog-release > RELEASE_BODY.md
       - uses: ncipollo/release-action@v1
         with:
-          bodyFile: 'RELEASE_BODY.md'
+          bodyFile: "RELEASE_BODY.md"
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Storybook
-        run: yarn storybook:build
-      - name: Extract version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-      - name: Deploy docs for this version
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./storybook-static
-          destination_dir: ${{ env.VERSION }}
-          keep_files: true
-      - name: Deploy docs as latest
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./storybook-static
-          destination_dir: latest
-          keep_files: true
-      - name: Create root redirect to latest
-        run: |
-          mkdir -p /tmp/root
-          cat > /tmp/root/index.html << 'REDIRECT'
-          <!DOCTYPE html>
-          <html>
-            <head>
-              <meta charset="utf-8">
-              <meta http-equiv="refresh" content="0;url=latest/">
-              <link rel="canonical" href="latest/">
-            </head>
-            <body>
-              <p>Redirecting to <a href="latest/">latest documentation</a>...</p>
-            </body>
-          </html>
-          REDIRECT
-      - name: Deploy root redirect
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: /tmp/root
-          keep_files: true
       - uses: italia/slack-notify-release-action@v0.4.0
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -21,13 +21,36 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
       - name: Install dependencies
         run: yarn
-      - name: Build documentation
+      - name: Build
         run: |
           yarn build
-      - name: Publish on gh-pages
-        run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           yarn storybook:build
-          yarn storybook:deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy docs as latest
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+          destination_dir: latest
+          keep_files: true
+      - name: Create root redirect to latest
+        run: |
+          mkdir -p /tmp/root
+          cat > /tmp/root/index.html << 'REDIRECT'
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0;url=latest/">
+              <link rel="canonical" href="latest/">
+            </head>
+            <body>
+              <p>Redirecting to <a href="latest/">latest documentation</a>...</p>
+            </body>
+          </html>
+          REDIRECT
+      - name: Deploy root redirect
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/root
+          keep_files: true

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -15,13 +15,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
           package-manager-cache: false
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./storybook-static
@@ -76,7 +76,7 @@ jobs:
           REDIRECT
 
       - name: Deploy root redirect
-        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
+        uses: peaceiris/actions-gh-pages@47f197a2200bb9de68ba5f48fad1c088eb1c4a32 # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: /tmp/root

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -2,36 +2,62 @@ name: Update documentation
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "v5*"
+
+permissions: {}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20.x'
+          node-version: 20
+          package-manager-cache: false
+
       - name: Git config
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
       - name: Install dependencies
         run: yarn
-      - name: Build
+
+      - name: Build docs
+        run: yarn storybook:build
+
+      - name: Extract destination folder name
         run: |
-          yarn build
-          yarn storybook:build
-      - name: Deploy docs as latest
-        uses: peaceiris/actions-gh-pages@v4
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            if [[ "${GITHUB_REF_NAME}" =~ ^v5\.[0-9]+\.[0-9]+$ ]]; then
+              echo "DEST_FOLDER=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+            else
+              echo "Invalid tag format: ${GITHUB_REF_NAME}. Expected v5.<minor>.<patch>" >&2
+              exit 1
+            fi
+          else
+            echo "DEST_FOLDER=latest" >> $GITHUB_ENV
+          fi
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./storybook-static
-          destination_dir: latest
-          keep_files: true
+          destination_dir: ${{ env.DEST_FOLDER }} # Subfolder name to deploy docs into
+          keep_files: false # Clear previous docs in destination subfolder to avoid orphaned files
+
       - name: Create root redirect to latest
         run: |
           mkdir -p /tmp/root
@@ -48,8 +74,9 @@ jobs:
             </body>
           </html>
           REDIRECT
+
       - name: Deploy root redirect
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: /tmp/root

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,6 +18,7 @@ const config: StorybookConfig = {
 
     return mergeConfig(config, {
       // Add dependencies to pre-optimization
+      base: './',
       build: {
         chunkSizeWarningLimit: 1000,
         minify: false

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "storybook:serve": "storybook dev -p 9001",
     "storybook:build": "storybook build --docs",
     "storybook:build:base": "storybook build",
-    "storybook:deploy": "npx gh-pages -d storybook-static -m 'chore: update documentation [ci skip]' --nojekyll",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && node scripts/wait-confirm && git add CHANGELOG.md",
     "postversion": "echo \"You can now publish your version using 'git push --follow-tags'\""
   },


### PR DESCRIPTION
Fixes #1233

## Summary

Each release now deploys Storybook docs into a versioned subdirectory (e.g. `/v5.10.0/`) while keeping `/latest/` updated. Previous versions stay accessible so users on older library versions can still browse matching docs.

## Changes

- **`.storybook/main.ts`** — set Vite `base: './'` so asset paths are relative and work from any subdirectory
- **`publish-release.yml`** — on tag push, deploy to `/<version>/` and `/latest/` using `peaceiris/actions-gh-pages` with `keep_files: true`; add root `index.html` redirect to `/latest/`
- **`update-docs.yml`** — same approach for manual doc updates, deploys to `/latest/`

## How it works

- `peaceiris/actions-gh-pages` with `destination_dir` and `keep_files: true` deploys into subdirectories without deleting existing ones
- Root `index.html` does a meta-refresh redirect to `latest/`, so existing links keep working
- Relative Vite base (`'./'`) means the same Storybook build works regardless of which subdirectory it's served from

Inspired by the approach in [dati-semantic-schema-editor](https://github.com/teamdigitale/dati-semantic-schema-editor/blob/main/.github/workflows/deploy-pages.yml) referenced in the issue discussion.